### PR TITLE
Fix lane valid generation for SIMD CAST

### DIFF
--- a/docs/CHANGELOG-PULP.md
+++ b/docs/CHANGELOG-PULP.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 In this sense, we interpret the "Public API" of a hardware module as its port/parameter list.
 Versions of the IP in the same major relase are "pin-compatible" with each other. Minor relases are permitted to add new parameters as long as their default bindings ensure backwards compatibility.
 
+## [pulp-v0.1.3] - 2023-07-19
+
+### Fixed
+- Fix `lane_valid` generation for SIMD CAST involving the largest precision available
+- Tie some potentially unused (depending on the FPU configuration) bits in `opgroup_multifmt_slice` to zero
+
 ## [pulp-v0.1.2] - 2023-06-12
 
 ### Fixed

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -509,10 +509,17 @@ or on 16b inputs producing 32b outputs");
       assign fmt_slice_result[fmt][Width-1:NUM_LANES*FP_WIDTH] = '{default: lane_ext_bit[0]};
   end
 
-  // Mute int results if unused
-  for (genvar ifmt = 0; ifmt < NUM_INT_FORMATS; ifmt++) begin : int_results_disabled
+  for (genvar ifmt = 0; ifmt < NUM_INT_FORMATS; ifmt++) begin : extend_or_mute_int_result
+    // Mute int results if unused
     if (OpGroup != fpnew_pkg::CONV) begin : mute_int_result
       assign ifmt_slice_result[ifmt] = '0;
+
+    // Extend slice result if needed
+    end else begin : extend_int_result
+      // Set up some constants
+      localparam int unsigned INT_WIDTH = fpnew_pkg::int_width(fpnew_pkg::int_format_e'(ifmt));
+      if (NUM_LANES*INT_WIDTH < Width)
+        assign ifmt_slice_result[ifmt][Width-1:NUM_LANES*INT_WIDTH] = '0;
     end
   end
 

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -209,8 +209,8 @@ or on 16b inputs producing 32b outputs");
       fpnew_pkg::status_t                      op_status;
 
       logic lane_is_used;
-      assign lane_is_used = (ACTIVE_FORMATS[src_fmt_i] & ~is_up_cast) |
-                            (ACTIVE_FORMATS[dst_fmt_i] &  is_up_cast) | (OpGroup == fpnew_pkg::DIVSQRT);
+      assign lane_is_used = (LANE_FORMATS[src_fmt_i] & ~is_up_cast) |
+                            (LANE_FORMATS[dst_fmt_i] &  is_up_cast) | (OpGroup == fpnew_pkg::DIVSQRT);
       assign in_valid = in_valid_i & ((lane == 0) | vectorial_op) & lane_is_used; // upper lanes only for vectors
 
       // Slice out the operands for this lane, upper bits are ignored in the unit


### PR DESCRIPTION
This PR fix tha `lane_valid` generation in the case of SIMD CAST instructions involving the widest precision available.
This PR also ties to zero some potentially unused bits.