### PR TITLE
Fix synchronization of THMULTI DivSqrt lanes when FP16ALT, FP8, or FP8ALT are enabled

### DIFF
--- a/docs/CHANGELOG-PULP.md
+++ b/docs/CHANGELOG-PULP.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 In this sense, we interpret the "Public API" of a hardware module as its port/parameter list.
 Versions of the IP in the same major relase are "pin-compatible" with each other. Minor relases are permitted to add new parameters as long as their default bindings ensure backwards compatibility.
 
+## [pulp-v0.2.1] - 2024-06-07
+
+### Fix
+- Fix synchronization of THMULTI DivSqrt lanes when FP16ALT, FP8, or FP8ALT are enabled.
+
 ## [pulp-v0.2.0] - 2024-05-29
 
 ### Added

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -628,10 +628,10 @@ or on 16b inputs producing 32b outputs");
 
   if ((DivSqrtSel != fpnew_pkg::TH32) && (OpGroup == fpnew_pkg::DIVSQRT)) begin
     // Synch lanes if there is more than one
-    assign simd_synch_rdy  = EnableVectors ? &divsqrt_ready : divsqrt_ready[0];
-    assign simd_synch_done = EnableVectors ? &divsqrt_done  : divsqrt_done[0];
+    assign simd_synch_rdy  = EnableVectors ? &divsqrt_ready[NUM_DIVSQRT_LANES-1:0] : divsqrt_ready[0];
+    assign simd_synch_done = EnableVectors ? &divsqrt_done[NUM_DIVSQRT_LANES-1:0]  : divsqrt_done[0];
   end else begin
-    // Unused (alternative divider only supported for scalar FP32 divsqrt)
+    // Unused (TH32 divider only supported for scalar FP32 divsqrt)
     assign simd_synch_rdy  = '0;
     assign simd_synch_done = '0;
   end


### PR DESCRIPTION
This PR fixes the synchronization of `THMULTI` DivSqrt lanes when `FP16ALT`, `FP8`, or `FP8ALT` are enabled. By applying this fix, the synchronization mechanism does not wait for the `FP16ALT`, `FP8`, or `FP8ALT` units to be ready (these are not instantiated when selecting `THMULTI` for the DivSqrt support).