### PR TITLE
Fix illegal Verilog assignment

### DIFF
--- a/docs/CHANGELOG-PULP.md
+++ b/docs/CHANGELOG-PULP.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 In this sense, we interpret the "Public API" of a hardware module as its port/parameter list.
 Versions of the IP in the same major relase are "pin-compatible" with each other. Minor relases are permitted to add new parameters as long as their default bindings ensure backwards compatibility.
 
+## [pulp-v0.2.3] - 2024-09-27
+
+### Fix
+- Fix illegal Verilog `'0`
+
 ## [pulp-v0.2.2] - 2024-06-24
 
 ### Added

--- a/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_round.v
+++ b/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_round.v
@@ -763,7 +763,7 @@ case(vfdsu_ex3_bfloat_expnt_rst[8:0])
   9'h17a:begin qt_result_bfloat_denorm_for_round[10:0] = {total_qt_rt_58[56:46]}; //-93 -6
                 bfloat_denorm_lst_frac =  1'b0;
           end//-1022 1
-  default:  begin qt_result_bfloat_denorm_for_round[10:0] = '0;
+  default:  begin qt_result_bfloat_denorm_for_round[10:0] = 11'b0;
                  bfloat_denorm_lst_frac = 1'b0;
             end//-1022 1
 endcase

--- a/vendor/patches/openc910/0001-Add-FP16ALT-support-to-THMULTI-DivSqrt-unit.patch
+++ b/vendor/patches/openc910/0001-Add-FP16ALT-support-to-THMULTI-DivSqrt-unit.patch
@@ -817,7 +817,7 @@ index 6eece52..a419289 100644
 +  9'h17a:begin qt_result_bfloat_denorm_for_round[10:0] = {total_qt_rt_58[56:46]}; //-93 -6
 +                bfloat_denorm_lst_frac =  1'b0;
 +          end//-1022 1
-+  default:  begin qt_result_bfloat_denorm_for_round[10:0] = '0;
++  default:  begin qt_result_bfloat_denorm_for_round[10:0] = 11'b0;
 +                 bfloat_denorm_lst_frac = 1'b0;
 +            end//-1022 1
 +endcase


### PR DESCRIPTION
This PR fixes an illegal Verilog `'0`