### PR TITLE
🩹 Fix result of not equal compare w signaling NaNs (#116)

### DIFF
--- a/src/fpnew_noncomp.sv
+++ b/src/fpnew_noncomp.sv
@@ -257,10 +257,12 @@ module fpnew_noncomp #(
     cmp_result = '0; // false
     cmp_status = '0; // no flags
 
-    // Signalling NaNs always compare as false and are illegal
-    if (signalling_nan) cmp_status.NV = 1'b1; // invalid operation
+    // Signalling NaNs always compare as false (except for "not equal" compares) and are illegal
+    if (signalling_nan) begin
+      cmp_status.NV = 1'b1; // invalid operation
+      cmp_result    = inp_pipe_rnd_mode_q[NUM_INP_REGS] == fpnew_pkg::RDN && inp_pipe_op_mod_q[NUM_INP_REGS];
     // Otherwise do comparisons
-    else begin
+    end else begin
       unique case (inp_pipe_rnd_mode_q[NUM_INP_REGS])
         fpnew_pkg::RNE: begin // Less than or equal
           if (any_operand_nan) cmp_status.NV = 1'b1; // Signalling comparison: NaNs are invalid


### PR DESCRIPTION
### Context
Needed for Spatz vmfne test with signaling NaN

### Original OpenHW PR description
* 🩹 Set result bit of not equal compare on signaling NaN

* 💡 Update comment w.r.t. signaling NaNs in compares