### PR TITLE
Add area efficient PACE support using FMA and loopback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *~
 html
-Bender.lock

--- a/Bender.yml
+++ b/Bender.yml
@@ -49,6 +49,15 @@ sources:
   - src/mxdotp/fpnew_mxdotp_multi_modules.sv
   - src/fpnew_mxdotp_multi.sv
   - src/fpnew_mxdotp_multi_wrapper.sv
+  - src/pace/fpnew_pace_cast.sv
+  - src/pace/fpnew_pace_decast.sv
+  - src/pace/fpnew_pace_bound_select.sv
+  - src/pace/fpnew_pace_coeff_select.sv
+  - src/pace/fpnew_pace_cmp.sv
+  - src/pace/fpnew_pace_frexp.sv
+  - src/pace/fpnew_pace_ldexp.sv
+  - src/pace/fpnew_pace_partition.sv
+  - src/fpnew_pace_fma_multi.sv
   - src/fpnew_opgroup_block.sv
   - src/fpnew_opgroup_fmt_slice.sv
   - src/fpnew_opgroup_multifmt_slice.sv

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -29,12 +29,14 @@ module fpnew_fma_multi #(
   input  logic                        rst_ni,
   // Input signals
   input  logic [2:0][WIDTH-1:0]       operands_i, // 3 operands
+  output logic [WIDTH-1:0]            pace_operand_o, // bypassed operand for PACE
   input  logic [NUM_FORMATS-1:0][2:0] is_boxed_i, // 3 operands
   input  fpnew_pkg::roundmode_e       rnd_mode_i,
   input  fpnew_pkg::operation_e       op_i,
   input  logic                        op_mod_i,
   input  fpnew_pkg::fp_format_e       src_fmt_i, // format of the multiplicands
   input  fpnew_pkg::fp_format_e       dst_fmt_i, // format of the addend and result
+  output fpnew_pkg::fp_format_e       pace_fmt_o, // format of the addend and result
   input  TagType                      tag_i,
   input  logic                        mask_i,
   input  AuxType                      aux_i,
@@ -501,6 +503,7 @@ module fpnew_fma_multi #(
   logic                  [0:NUM_MID_REGS]                         mid_pipe_mask_q;
   AuxType                [0:NUM_MID_REGS]                         mid_pipe_aux_q;
   logic                  [0:NUM_MID_REGS]                         mid_pipe_valid_q;
+  logic                  [0:NUM_MID_REGS][WIDTH-1:0]              mid_pipe_pace_operand_q;
   // Ready signal is combinatorial for all stages
   logic [0:NUM_MID_REGS] mid_pipe_ready;
 
@@ -522,6 +525,7 @@ module fpnew_fma_multi #(
   assign mid_pipe_mask_q[0]        = inp_pipe_mask_q[NUM_INP_REGS];
   assign mid_pipe_aux_q[0]         = inp_pipe_aux_q[NUM_INP_REGS];
   assign mid_pipe_valid_q[0]       = inp_pipe_valid_q[NUM_INP_REGS];
+  assign mid_pipe_pace_operand_q[0]= inp_pipe_operands_q[NUM_INP_REGS][1];
   // Input stage: Propagate pipeline ready signal to input pipe
   assign inp_pipe_ready[NUM_INP_REGS] = mid_pipe_ready[0];
 
@@ -553,6 +557,7 @@ module fpnew_fma_multi #(
     `FFL(mid_pipe_spec_stat_q[i+1],   mid_pipe_spec_stat_q[i],   reg_ena, '0)
     `FFL(mid_pipe_tag_q[i+1],         mid_pipe_tag_q[i],         reg_ena, TagType'('0))
     `FFL(mid_pipe_mask_q[i+1],        mid_pipe_mask_q[i],        reg_ena, '0)
+    `FFL(mid_pipe_pace_operand_q[i+1],mid_pipe_pace_operand_q[i],reg_ena, '0)
     `FFL(mid_pipe_aux_q[i+1],         mid_pipe_aux_q[i],         reg_ena, AuxType'('0))
   end
   // Output stage: assign selected pipe outputs to signals for later use
@@ -800,16 +805,21 @@ module fpnew_fma_multi #(
   logic               [0:NUM_OUT_REGS]            out_pipe_mask_q;
   AuxType             [0:NUM_OUT_REGS]            out_pipe_aux_q;
   logic               [0:NUM_OUT_REGS]            out_pipe_valid_q;
+  logic               [0:NUM_OUT_REGS][WIDTH-1:0] out_pipe_pace_operand_q;
+  fpnew_pkg::fp_format_e [0:NUM_OUT_REGS]         out_pipe_dst_fmt_q;
+
   // Ready signal is combinatorial for all stages
   logic [0:NUM_OUT_REGS] out_pipe_ready;
 
   // Input stage: First element of pipeline is taken from inputs
-  assign out_pipe_result_q[0] = result_d;
-  assign out_pipe_status_q[0] = status_d;
-  assign out_pipe_tag_q[0]    = mid_pipe_tag_q[NUM_MID_REGS];
-  assign out_pipe_mask_q[0]   = mid_pipe_mask_q[NUM_MID_REGS];
-  assign out_pipe_aux_q[0]    = mid_pipe_aux_q[NUM_MID_REGS];
-  assign out_pipe_valid_q[0]  = mid_pipe_valid_q[NUM_MID_REGS];
+  assign out_pipe_result_q[0]        = result_d;
+  assign out_pipe_status_q[0]        = status_d;
+  assign out_pipe_tag_q[0]           = mid_pipe_tag_q[NUM_MID_REGS];
+  assign out_pipe_mask_q[0]          = mid_pipe_mask_q[NUM_MID_REGS];
+  assign out_pipe_aux_q[0]           = mid_pipe_aux_q[NUM_MID_REGS];
+  assign out_pipe_valid_q[0]         = mid_pipe_valid_q[NUM_MID_REGS];
+  assign out_pipe_pace_operand_q[0]  = mid_pipe_pace_operand_q[NUM_MID_REGS];
+  assign out_pipe_dst_fmt_q[0]       = mid_pipe_dst_fmt_q[NUM_MID_REGS];
   // Input stage: Propagate pipeline ready signal to inside pipe
   assign mid_pipe_ready[NUM_MID_REGS] = out_pipe_ready[0];
   // Generate the register stages
@@ -830,12 +840,16 @@ module fpnew_fma_multi #(
     `FFL(out_pipe_tag_q[i+1],    out_pipe_tag_q[i],    reg_ena, TagType'('0))
     `FFL(out_pipe_mask_q[i+1],   out_pipe_mask_q[i],   reg_ena, '0)
     `FFL(out_pipe_aux_q[i+1],    out_pipe_aux_q[i],    reg_ena, AuxType'('0))
+    `FFL(out_pipe_pace_operand_q[i+1], out_pipe_pace_operand_q[i], reg_ena, '0)
+    `FFL(out_pipe_dst_fmt_q[i+1], out_pipe_dst_fmt_q[i], reg_ena, fpnew_pkg::fp_format_e'('0))
   end
   // Output stage: Ready travels backwards from output side, driven by downstream circuitry
   assign out_pipe_ready[NUM_OUT_REGS] = out_ready_i;
   // Output stage: assign module outputs
   assign result_o        = out_pipe_result_q[NUM_OUT_REGS];
   assign status_o        = out_pipe_status_q[NUM_OUT_REGS];
+  assign pace_operand_o  = out_pipe_pace_operand_q[NUM_OUT_REGS];
+  assign pace_fmt_o      = out_pipe_dst_fmt_q[NUM_OUT_REGS];
   assign extension_bit_o = 1'b1; // always NaN-Box result
   assign tag_o           = out_pipe_tag_q[NUM_OUT_REGS];
   assign mask_o          = out_pipe_mask_q[NUM_OUT_REGS];

--- a/src/fpnew_opgroup_block.sv
+++ b/src/fpnew_opgroup_block.sv
@@ -26,6 +26,7 @@ module fpnew_opgroup_block #(
   parameter fpnew_pkg::fmt_unsigned_t   FmtPipeRegs   = '{default: 0},
   parameter fpnew_pkg::fmt_unit_types_t FmtUnitTypes  = '{default: fpnew_pkg::PARALLEL},
   parameter fpnew_pkg::pipe_config_t    PipeConfig    = fpnew_pkg::BEFORE,
+  parameter fpnew_pkg::pace_features_t  PaceFeatures  = '{default: 0},
   parameter type                        TagType       = logic,
   parameter logic                       TrueSIMDClass = 1'b0,
   parameter logic                       CompressedVecCmpResult = 1'b0,
@@ -34,7 +35,10 @@ module fpnew_opgroup_block #(
   localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS,
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
   localparam int unsigned NUM_LANES    = fpnew_pkg::max_num_lanes(Width, FpFmtMask, EnableVectors),
-  localparam type         MaskType     = logic [NUM_LANES-1:0]
+  localparam type         MaskType     = logic [NUM_LANES-1:0],
+  localparam int unsigned PaceParamWidth = PaceFeatures.PaceParamWidth,
+  localparam int unsigned PaceParamMsb   = (PaceParamWidth > 0) ? (PaceParamWidth - 1) : 0
+
 ) (
   input logic                                     clk_i,
   input logic                                     rst_ni,
@@ -64,7 +68,9 @@ module fpnew_opgroup_block #(
   output logic                                    out_valid_o,
   input  logic                                    out_ready_i,
   // Indication of valid data in flight
-  output logic                                    busy_o
+  output logic                                    busy_o,
+  input  logic [PaceParamMsb:0]                   pace_param_i,
+  input  fpnew_pkg::pace_mode_t                   pace_mode_i
 );
 
   // ----------------
@@ -190,6 +196,7 @@ module fpnew_opgroup_block #(
       .DivSqrtSel     ( DivSqrtSel       ),
       .NumPipeRegs    ( REG              ),
       .PipeConfig     ( PipeConfig       ),
+      .PaceFeatures  ( PaceFeatures     ),
       .TagType        ( TagType          ),
       .StochasticRndImplementation ( StochasticRndImplementation )
     ) i_multifmt_slice (
@@ -216,7 +223,9 @@ module fpnew_opgroup_block #(
       .tag_o           ( fmt_outputs[FMT].tag     ),
       .out_valid_o     ( fmt_out_valid[FMT]       ),
       .out_ready_i     ( fmt_out_ready[FMT]       ),
-      .busy_o          ( fmt_busy[FMT]            )
+      .busy_o          ( fmt_busy[FMT]            ),
+      .pace_param_i    ( pace_param_i             ),
+      .pace_mode_i     ( pace_mode_i              )
     );
 
   end

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -27,13 +27,19 @@ module fpnew_opgroup_multifmt_slice #(
   parameter fpnew_pkg::divsqrt_unit_t DivSqrtSel     = fpnew_pkg::THMULTI,
   parameter int unsigned              NumPipeRegs    = 0,
   parameter fpnew_pkg::pipe_config_t  PipeConfig     = fpnew_pkg::BEFORE,
+  parameter fpnew_pkg::pace_features_t PaceFeatures  = '{default: 0},
+  parameter int unsigned             PaceDataWidth = PaceFeatures.PaceDataWidth,
+  parameter fpnew_pkg::fmt_logic_t   PaceFmtConfig = PaceFeatures.FmtConfig,
   parameter type                      TagType        = logic,
   parameter fpnew_pkg::rsr_impl_t     StochasticRndImplementation = fpnew_pkg::DEFAULT_NO_RSR,
   // Do not change
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
   localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS,
   localparam int unsigned NUM_SIMD_LANES = fpnew_pkg::max_num_lanes(Width, FpFmtConfig, EnableVectors),
-  localparam type         MaskType     = logic [NUM_SIMD_LANES-1:0]
+  localparam type         MaskType     = logic [NUM_SIMD_LANES-1:0],
+  localparam int unsigned PaceParamWidth = PaceFeatures.PaceParamWidth,
+  localparam int unsigned PaceParamMsb   = (PaceParamWidth > 0) ? (PaceParamWidth - 1) : 0
+
 ) (
   input logic                                     clk_i,
   input logic                                     rst_ni,
@@ -63,8 +69,14 @@ module fpnew_opgroup_multifmt_slice #(
   output logic                                    out_valid_o,
   input  logic                                    out_ready_i,
   // Indication of valid data in flight
-  output logic                                    busy_o
+  output logic                                    busy_o,
+  input  logic [PaceParamMsb:0]                   pace_param_i,
+  input  fpnew_pkg::pace_mode_t                   pace_mode_i
 );
+
+  fpnew_pkg::operation_e                    pace_op;
+
+  assign pace_op = op_i;
 
   if ((OpGroup == fpnew_pkg::DIVSQRT)) begin
     if ((DivSqrtSel == fpnew_pkg::TH32) && !((FpFmtConfig[0] == 1) && (FpFmtConfig[1:NUM_FORMATS-1] == '0))) begin
@@ -186,6 +198,9 @@ or on 16b inputs producing 32b outputs");
   // ---------------
   // Generate Lanes
   // ---------------
+  localparam int unsigned PaceMaxDataWidth = fpnew_pkg::max_fp_width(PaceFmtConfig);
+  localparam fpnew_pkg::fp_encoding_t PaceSuperFmt = fpnew_pkg::super_format(PaceFmtConfig);
+  localparam int unsigned PaceMaxManWidth = PaceSuperFmt.man_bits;
   for (genvar lane = 0; lane < int'(NUM_LANES); lane++) begin : gen_num_lanes
     localparam int unsigned LANE = unsigned'(lane); // unsigned to please the linter
     // Get a mask of active formats for this lane
@@ -194,7 +209,9 @@ or on 16b inputs producing 32b outputs");
     localparam fpnew_pkg::ifmt_logic_t ACTIVE_INT_FORMATS =
         fpnew_pkg::get_lane_int_formats(Width, FpFmtConfig, IntFmtConfig, LANE);
     localparam int unsigned MAX_WIDTH = fpnew_pkg::max_fp_width(ACTIVE_FORMATS);
-
+    localparam fpnew_pkg::fmt_logic_t PaceActiveFormats =
+        fpnew_pkg::get_pace_lane_formats(ACTIVE_FORMATS, PaceFmtConfig);
+    localparam int unsigned EnablePace = (PaceActiveFormats != 0);
     // Cast-specific parameters
     localparam fpnew_pkg::fmt_logic_t CONV_FORMATS =
         fpnew_pkg::get_conv_lane_formats(Width, FpFmtConfig, LANE);
@@ -278,39 +295,91 @@ or on 16b inputs producing 32b outputs");
       end
 
       // Instantiate the operation from the selected opgroup
-      if (OpGroup == fpnew_pkg::ADDMUL) begin : lane_instance
-        fpnew_fma_multi #(
-          .FpFmtConfig ( LANE_FORMATS         ),
-          .NumPipeRegs ( NumPipeRegs          ),
-          .PipeConfig  ( PipeConfig           ),
-          .TagType     ( TagType              ),
-          .AuxType     ( logic [AUX_BITS-1:0] )
-        ) i_fpnew_fma_multi (
-          .clk_i,
-          .rst_ni,
-          .operands_i      ( local_operands  ),
-          .is_boxed_i,
-          .rnd_mode_i      ( rnd_mode        ),
-          .op_i,
-          .op_mod_i,
-          .src_fmt_i,
-          .dst_fmt_i,
-          .tag_i,
-          .mask_i          ( simd_mask_i[lane]   ),
-          .aux_i           ( aux_data            ),
-          .in_valid_i      ( in_valid            ),
-          .in_ready_o      ( lane_in_ready[lane] ),
-          .flush_i,
-          .result_o        ( op_result           ),
-          .status_o        ( op_status           ),
-          .extension_bit_o ( lane_ext_bit[lane]  ),
-          .tag_o           ( lane_tags[lane]     ),
-          .mask_o          ( lane_masks[lane]    ),
-          .aux_o           ( lane_aux[lane]      ),
-          .out_valid_o     ( out_valid           ),
-          .out_ready_i     ( out_ready           ),
-          .busy_o          ( lane_busy[lane]     )
-        );
+      if (OpGroup == fpnew_pkg::ADDMUL) begin : gen_lane_instance
+        if (EnablePace) begin : gen_pace_instance
+          localparam fpnew_pkg::pace_features_t PaceLaneFeatures = '{
+            PaceDegree     : PaceFeatures.PaceDegree,
+            PaceParts      : PaceFeatures.PaceParts,
+            PaceEps        : PaceFeatures.PaceEps,
+            PaceDataWidth  : PaceFeatures.PaceDataWidth,
+            PaceParamWidth : PaceFeatures.PaceParamWidth,
+            PacePipeDist   : PaceFeatures.PacePipeDist,
+            FmtConfig      : PaceActiveFormats
+          };
+
+          fpnew_pace_fma_multi #(
+            .FpFmtConfig ( LANE_FORMATS         ),
+            .NumPipeRegs ( NumPipeRegs          ),
+            .PipeConfig  ( PipeConfig           ),
+            .TagType     ( TagType              ),
+            .AuxType     ( logic [AUX_BITS-1:0] ),
+            .PaceFeat    ( PaceLaneFeatures     ),
+            .PaceDataW   ( PaceMaxDataWidth     ),
+            .PaceManOff  ( PaceMaxManWidth      )
+          ) i_pace_fma_multi (
+            .clk_i,
+            .rst_ni,
+            .operands_i      ( local_operands  ),
+            .is_boxed_i,
+            .rnd_mode_i      ( rnd_mode        ),
+            .op_i            ( pace_op         ),
+            .op_mod_i,
+            .src_fmt_i,
+            .dst_fmt_i,
+            .tag_i,
+            .mask_i          ( simd_mask_i[lane]   ),
+            .aux_i           ( aux_data            ),
+            .in_valid_i      ( in_valid            ),
+            .in_ready_o      ( lane_in_ready[lane] ),
+            .flush_i,
+            .result_o        ( op_result           ),
+            .status_o        ( op_status           ),
+            .extension_bit_o ( lane_ext_bit[lane]  ),
+            .tag_o           ( lane_tags[lane]     ),
+            .mask_o          ( lane_masks[lane]    ),
+            .aux_o           ( lane_aux[lane]      ),
+            .out_valid_o     ( out_valid           ),
+            .out_ready_i     ( out_ready           ),
+            .busy_o          ( lane_busy[lane]     ),
+            .pace_param_i    ( pace_param_i        ),
+            .pace_mode_i     ( pace_mode_i         )
+          );
+        end else begin : gen_fma_instance
+          fpnew_fma_multi #(
+            .FpFmtConfig ( LANE_FORMATS            ),
+            .NumPipeRegs ( NumPipeRegs             ),
+            .PipeConfig  ( PipeConfig              ),
+            .TagType     ( TagType                 ),
+            .AuxType     ( logic [AUX_BITS-1:0]    )
+          ) i_fma_multi (
+            .clk_i,
+            .rst_ni,
+            .operands_i      ( local_operands      ),
+            .is_boxed_i,
+            .rnd_mode_i      ( rnd_mode            ),
+            .op_i            ( op_i                ),
+            .op_mod_i,
+            .src_fmt_i,
+            .dst_fmt_i,
+            .pace_fmt_o      (                     ),
+            .pace_operand_o  (                     ),
+            .tag_i,
+            .mask_i          ( simd_mask_i[lane]   ),
+            .aux_i           ( aux_data            ),
+            .in_valid_i      ( in_valid            ),
+            .in_ready_o      ( lane_in_ready[lane] ),
+            .flush_i,
+            .result_o        ( op_result           ),
+            .status_o        ( op_status           ),
+            .extension_bit_o ( lane_ext_bit[lane]  ),
+            .tag_o           ( lane_tags[lane]     ),
+            .mask_o          ( lane_masks[lane]    ),
+            .aux_o           ( lane_aux[lane]      ),
+            .out_valid_o     ( out_valid           ),
+            .out_ready_i     ( out_ready           ),
+            .busy_o          ( lane_busy[lane]     )
+          );
+        end
       end else if (OpGroup == fpnew_pkg::DOTP) begin : lane_instance
         fpnew_sdotp_multi_wrapper #(
           .LaneWidth   ( LANE_WIDTH           ),

--- a/src/fpnew_pace_fma_multi.sv
+++ b/src/fpnew_pace_fma_multi.sv
@@ -1,0 +1,496 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+// Wrapper around the FMA engine that also handles PACE polynomial evaluation.
+module fpnew_pace_fma_multi #(
+  parameter fpnew_pkg::fmt_logic_t      FpFmtConfig   = '1,
+  parameter int unsigned                NumPipeRegs   = 0,
+  parameter fpnew_pkg::pipe_config_t    PipeConfig    = fpnew_pkg::BEFORE,
+  parameter fpnew_pkg::pace_features_t  PaceFeat      = '{default: 0},
+  parameter fpnew_pkg::fmt_logic_t      FmtConfig     = 6'h2F,
+  parameter fpnew_pkg::fmt_logic_t      PaceFmtCfg    = PaceFeat.FmtConfig,
+  parameter int unsigned                PaceDataW     = 0,
+  parameter int unsigned                PaceManOff    = 0,
+  parameter type                        TagType       = logic,
+  parameter type                        AuxType       = logic,
+  localparam int unsigned               Parts         = PaceFeat.PaceParts,
+  localparam int unsigned               Degrees       = PaceFeat.PaceDegree,
+  localparam int unsigned               Eps           = PaceFeat.PaceEps,
+  localparam int unsigned               Bounds        = Parts - 1,
+  localparam int unsigned               BoundStages   = $clog2(Bounds),
+  parameter int unsigned                PipeRegs      = PaceFeat.PacePipeDist,
+  localparam int unsigned               DegreesBits   = $clog2(Degrees + 1),
+  localparam int unsigned               ParamWidth    = PaceFeat.PaceParamWidth,
+  localparam int unsigned               ParamMsb      = (ParamWidth > 0) ? (ParamWidth - 1) : 0,
+  localparam int unsigned               FmaScoreboardDepth =
+      NumPipeRegs > 0 ? NumPipeRegs : 1,
+  // Do not change
+  localparam int unsigned               Width         = fpnew_pkg::max_fp_width(FpFmtConfig),
+  localparam int unsigned               NumFormats    = fpnew_pkg::NUM_FP_FORMATS,
+  localparam fpnew_pkg::fp_encoding_t   SuperFormat   = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned               SuperExpBits  = SuperFormat.exp_bits,
+  localparam int unsigned               SuperManBits  = SuperFormat.man_bits,
+  localparam int unsigned               SuperWidth    =
+      1 + SuperFormat.man_bits + SuperFormat.exp_bits
+) (
+  input  logic                        clk_i,
+  input  logic                        rst_ni,
+  // Input signals
+  input  logic [2:0][Width-1:0]       operands_i,
+  input  logic [NumFormats-1:0][2:0]  is_boxed_i,
+  input  fpnew_pkg::roundmode_e       rnd_mode_i,
+  input  fpnew_pkg::operation_e       op_i,
+  input  logic                        op_mod_i,
+  input  fpnew_pkg::fp_format_e       src_fmt_i,
+  input  fpnew_pkg::fp_format_e       dst_fmt_i,
+  input  TagType                      tag_i,
+  input  logic                        mask_i,
+  input  AuxType                      aux_i,
+  // Input Handshake
+  input  logic                        in_valid_i,
+  output logic                        in_ready_o,
+  input  logic                        flush_i,
+  // Output signals
+  output logic [Width-1:0]            result_o,
+  output fpnew_pkg::status_t          status_o,
+  output logic                        extension_bit_o,
+  output TagType                      tag_o,
+  output logic                        mask_o,
+  output AuxType                      aux_o,
+  // Output handshake
+  output logic                        out_valid_o,
+  input  logic                        out_ready_i,
+  // Indication of valid data in flight
+  output logic                        busy_o,
+  input  logic [ParamMsb:0]           pace_param_i,
+  input  fpnew_pkg::pace_mode_t       pace_mode_i
+);
+
+  localparam int unsigned NumCoeffs = (Degrees + 1) * Parts;
+  localparam fpnew_pkg::fp_encoding_t PaceFmt = fpnew_pkg::super_format(PaceFmtCfg);
+  localparam int unsigned PaceW = fpnew_pkg::max_fp_width(PaceFmtCfg);
+  localparam int unsigned PaceFmtW = 1 + PaceFmt.man_bits + PaceFmt.exp_bits;
+  localparam int unsigned PaceExpBits = PaceFmt.exp_bits;
+  localparam int unsigned PaceManBits = PaceFmt.man_bits;
+  // Limit the local datapath width if FPNew supports formats wider than PACE needs.
+  localparam int unsigned LocalW = (Width > PaceDataW) ? PaceDataW : Width;
+
+  logic [LocalW-1:0] red_in;
+
+  typedef struct packed {
+    logic sign;
+    logic lt_eps;
+    logic [PaceExpBits-1:0] exponent;
+    logic sqrt;
+    logic inv;
+    logic rsqrt;
+  } inv_tag_t;
+
+  typedef struct packed {
+    TagType user_tag;
+    inv_tag_t inv_tag;
+    logic mask;
+    AuxType aux;
+    fpnew_pkg::fp_format_e src_fmt;
+  } part_tag_t;
+
+  typedef struct packed {
+    TagType user_tag;
+    inv_tag_t inv_tag;
+    logic [DegreesBits-1:0] degree;
+    logic [BoundStages-1:0] part_id;
+    logic active;
+  } fma_tag_t;
+
+  // ----------------
+  // Datapath Signals
+  // ----------------
+  logic [2:0][Width-1:0] fma_ops_in;
+  logic [2:0][Width-1:0] horn_ops;
+
+  logic [Width-1:0] fma_bypass_op;
+  logic [LocalW-1:0] part_in_op;
+  logic [LocalW-1:0] part_op;
+  logic [LocalW-1:0] fr_in_op;
+  logic [1:0][LocalW-1:0] coeff_pair;
+  logic [NumFormats-1:0][2:0] fma_is_boxed;
+  fpnew_pkg::roundmode_e fma_round_mode;
+  fpnew_pkg::operation_e fma_op;
+  logic fma_op_mod;
+  fpnew_pkg::fp_format_e fma_src_fmt;
+  fpnew_pkg::fp_format_e fma_dst_fmt;
+  fpnew_pkg::fp_format_e pace_fmt;
+  fpnew_pkg::fp_format_e part_fmt;
+  fma_tag_t in_tag;
+  logic fma_in_mask;
+  AuxType fma_in_aux;
+  // Input Handshake
+  logic fma_in_valid;
+  logic fma_in_ready;
+  logic fma_flush;
+  // Output signals
+  logic [Width-1:0] fma_res;
+  fpnew_pkg::status_t fma_status_flags;
+  logic fma_extension_bit;
+  fma_tag_t out_tag;
+  logic fma_output_mask;
+  AuxType fma_output_aux;
+  // Output handshake
+  logic fma_vld;
+  logic fma_rdy;
+  // Indication of valid data in flight
+  logic fma_busy;
+  logic part_busy;
+  logic part_inflight;
+  logic [BoundStages-1:0] part_idx;
+
+  logic [PaceW-1:0] scaled_result;
+  logic [PaceW-1:0] ld_in_op;
+
+  // Polynomial coefficients and optional inverse/sqrt parameters.
+  logic [Degrees:0][Bounds:0][LocalW-1:0] coeff_table;
+  logic [Bounds-1:0][PaceFmtW-1:0]        partition_bounds;
+  logic [PaceW-1:0]                       eps_th;
+  logic [PaceW-1:0]                       eps_out;
+
+  // ----------------
+  // Control Signals
+  // ----------------
+  part_tag_t ptag_in, ptag_out;
+  logic horn_fb;
+  logic horn_act;
+  logic pace_op;
+  logic pwpa_op;
+  logic inv_op;
+  logic sqrt_op;
+  logic rsqrt_op;
+  logic do_inv;
+  logic [FmaScoreboardDepth-1:0] inflight_q;
+  logic [FmaScoreboardDepth-1:0] inflight_d;
+  logic pin_vld, pin_rdy;
+  logic pout_vld, pout_rdy;
+  inv_tag_t inv_info;
+  inv_tag_t out_inv;
+  fpnew_pkg::pace_mode_t fr_mode;
+
+  for (genvar deg = 0; deg <= Degrees; deg++) begin : gen_coeffs
+    for (genvar part = 0; part < Parts; part++) begin : gen_coeff
+      localparam int unsigned ParamIdx = deg * Parts + part;
+      localparam int unsigned ParamOff = ParamIdx * PaceDataW;
+      assign coeff_table[deg][part] = pace_param_i[ParamOff +: LocalW];
+    end
+  end
+
+  if (Parts > 1) begin : gen_partition_bounds
+    for (genvar partition = 0; partition < Bounds; partition++) begin : gen_bound_entry
+      localparam int unsigned BoundIdx = NumCoeffs + partition;
+      localparam int unsigned BoundOff = BoundIdx * PaceDataW;
+      assign partition_bounds[partition] = {
+        pace_param_i[BoundOff + PaceDataW - 1],
+        pace_param_i[BoundOff + PaceManOff +: PaceExpBits],
+        pace_param_i[BoundOff +: PaceManBits]
+      };
+    end
+  end
+
+  if (Eps == 1) begin : gen_eps_params
+    localparam int unsigned EpsIdx    = NumCoeffs + Bounds;
+    localparam int unsigned EpsOff    = EpsIdx * PaceDataW;
+    localparam int unsigned EpsOutIdx = NumCoeffs + Bounds + 1;
+    localparam int unsigned EpsOutOff = EpsOutIdx * PaceDataW;
+    assign eps_th = {
+      pace_param_i[EpsOff + PaceDataW - 1],
+      pace_param_i[EpsOff + PaceManOff +: PaceExpBits],
+      pace_param_i[EpsOff +: PaceManBits]
+    };
+    assign eps_out = pace_param_i[EpsOutOff +: LocalW];
+  end else begin : gen_no_eps_params
+    assign eps_th = '0;
+    assign eps_out    = '0;
+  end
+
+  // Partition-stage tag payload.
+  assign ptag_in.user_tag    = tag_i;
+  assign ptag_in.inv_tag     = inv_info;
+  assign ptag_in.mask        = mask_i;
+  assign ptag_in.aux         = aux_i;
+  assign ptag_in.src_fmt     = src_fmt_i;
+
+  assign pwpa_op = (op_i == fpnew_pkg::PWPA);
+  assign inv_op = (op_i == fpnew_pkg::PACE_INV);
+  assign sqrt_op = (op_i == fpnew_pkg::PACE_SQRT);
+  assign rsqrt_op = (op_i == fpnew_pkg::PACE_RSQRT);
+  assign pace_op = pwpa_op | rsqrt_op | inv_op | sqrt_op;
+  assign do_inv = inv_op | sqrt_op | rsqrt_op;
+  assign fr_mode = '{
+    inv:    inv_op,
+    sqrt:   sqrt_op,
+    rsqrt:  rsqrt_op,
+    extend: pace_mode_i.extend,
+    enable: pace_mode_i.enable,
+    degree: pace_mode_i.degree
+  };
+  assign horn_act = horn_fb ? 1'b1 : pout_vld;
+
+  assign fma_flush       = flush_i;
+  assign status_o        = fma_status_flags;
+  assign extension_bit_o = fma_extension_bit;
+  assign tag_o           = out_tag.user_tag;
+  assign mask_o          = fma_output_mask;
+  assign aux_o           = fma_output_aux;
+  assign busy_o          = fma_busy | horn_fb | part_busy;
+  assign out_inv = out_tag.inv_tag;
+
+  always_comb begin
+    inflight_d = inflight_q;
+
+    if (fma_vld & fma_rdy & out_tag.active) begin
+      if (FmaScoreboardDepth == 1) begin
+        inflight_d = '0;
+      end else begin
+        inflight_d = {1'b0, inflight_d[FmaScoreboardDepth-1:1]};
+      end
+    end
+
+    if (pout_vld & pout_rdy) begin
+      inflight_d[0] = 1'b1;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      inflight_q <= '0;
+    end else begin
+      inflight_q <= inflight_d;
+    end
+  end
+
+  always_comb begin
+    in_tag = '0;
+    in_tag.user_tag = tag_i;
+    in_tag.degree = 1;
+    in_tag.part_id = part_idx;
+    in_tag.active = horn_act;
+
+    if (horn_act) begin
+      in_tag.user_tag = ptag_out.user_tag;
+      in_tag.inv_tag = ptag_out.inv_tag;
+      in_tag.part_id = part_idx;
+    end
+
+    if (horn_fb) begin
+      in_tag.user_tag = out_tag.user_tag;
+      in_tag.inv_tag = out_tag.inv_tag;
+      in_tag.degree = out_tag.degree + 1;
+      in_tag.part_id = out_tag.part_id;
+    end
+  end
+
+  always_comb begin
+    fma_round_mode = rnd_mode_i;
+    fma_op         = op_i;
+    fma_op_mod     = op_mod_i;
+    fma_ops_in     = operands_i;
+    fma_src_fmt    = src_fmt_i;
+    fma_dst_fmt    = dst_fmt_i;
+    fma_in_mask    = mask_i;
+    fma_in_aux     = aux_i;
+    fma_is_boxed   = is_boxed_i;
+    fma_in_valid   = pace_op ? 1'b0 : in_valid_i;
+    fma_rdy        = out_ready_i;
+    in_ready_o     = fma_in_ready;
+    out_valid_o    = fma_vld;
+    pin_vld        = 1'b0;
+    pout_rdy       = 1'b0;
+
+    if (pace_op) begin
+      in_ready_o = pin_rdy;
+      pin_vld = in_valid_i;
+    end
+
+    if (horn_act) begin
+      fma_round_mode = fpnew_pkg::RNE;
+      fma_op = fpnew_pkg::FMADD;
+      fma_op_mod = 1'b0;
+      fma_ops_in = horn_ops;
+      fma_src_fmt = part_fmt;
+      fma_dst_fmt = part_fmt;
+      fma_in_mask = ptag_out.mask;
+      fma_in_aux = ptag_out.aux;
+      fma_is_boxed = '1;
+      fma_in_valid = pout_vld;
+      pout_rdy = fma_in_ready;
+    end
+
+    if (horn_fb) begin
+      fma_ops_in = horn_ops;
+      fma_src_fmt = pace_fmt;
+      fma_dst_fmt = pace_fmt;
+      fma_in_mask = fma_output_mask;
+      fma_in_aux = fma_output_aux;
+      fma_in_valid = fma_vld;
+      fma_rdy = 1'b1;
+      in_ready_o = 1'b0;
+      out_valid_o = 1'b0;
+      pin_vld = 1'b0;
+      pout_rdy = 1'b0;
+    end
+
+    if (!pace_op && (part_inflight | (|inflight_q) | horn_fb)) begin
+      in_ready_o = 1'b0;
+    end
+  end
+
+  assign result_o = out_tag.active
+                  ? {{(Width - PaceW){fma_res[Width-1]}}, scaled_result}
+                  : fma_res;
+
+  // Horner evaluation uses a*b + c with the selected coefficient pair.
+  always_comb begin
+    horn_ops = '0;
+    horn_ops[2][LocalW-1:0] = coeff_pair[1];
+    horn_ops[1][LocalW-1:0] = horn_fb ? fma_bypass_op[LocalW-1:0] : part_op;
+    horn_ops[0][LocalW-1:0] = horn_fb ? fma_res[LocalW-1:0] : coeff_pair[0];
+  end
+
+  assign horn_fb =
+      fma_vld & out_tag.active & (out_tag.degree < pace_mode_i.degree);
+
+  // Decompose and rescale data for inverse/sqrt-style PACE modes.
+  assign fr_in_op = operands_i[0][LocalW-1:0];
+  assign ld_in_op = fma_res[PaceW-1:0];
+
+  fpnew_pace_frexp #(
+    .FpFmtConfig(PaceFmtCfg),
+    .FrexpInfoType(inv_tag_t)
+  ) i_pace_frexp (
+    .clk_i,
+    .rst_ni,
+    .src_fmt_i(src_fmt_i),
+    .pace_mode_i(fr_mode),
+    .eps_i(eps_th),
+    .operand_i(fr_in_op),
+    .operand_o(red_in),
+    .frexp_info_o(inv_info)
+  );
+
+  fpnew_pace_ldexp #(
+    .FpFmtConfig(PaceFmtCfg)
+  ) i_pace_ldexp (
+    .op_inv_i(out_inv.inv),
+    .op_sqrt_i(out_inv.sqrt),
+    .op_rsqrt_i(out_inv.rsqrt),
+    .pace_op_i(out_tag.active),
+    .src_fmt_i(pace_fmt),
+    .eps_val_i(eps_out),
+    .operand_i(ld_in_op),
+    .sign_i(out_inv.sign),
+    .lt_eps_i(out_inv.lt_eps),
+    .exponent_i(out_inv.exponent),
+    .operand_o(scaled_result)
+  );
+
+  assign part_in_op = do_inv ? red_in : operands_i[0][LocalW-1:0];
+
+  if (Parts > 1) begin : gen_part_detect
+    fpnew_pace_partition #(
+      .FpFmtConfig(PaceFmtCfg),
+      .Bounds(Bounds),
+      .PipeRegs(PipeRegs),
+      .NumCmpStages(BoundStages),
+      .TagType(part_tag_t)
+    ) i_partition_detector (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .bounds_i(partition_bounds),
+      .operand_i(part_in_op),
+      .operand_o(part_op),
+      .src_fmt_i(src_fmt_i),
+      .dst_fmt_o(part_fmt),
+      .tag_i(ptag_in),
+      .in_valid_i(pin_vld),
+      .in_ready_o(pin_rdy),
+      .bound_id_o(part_idx),
+      .tag_o(ptag_out),
+      .out_valid_o(pout_vld),
+      .out_ready_i(pout_rdy),
+      .inflight_o(part_inflight),
+      .busy_o(part_busy)
+    );
+  end else begin : gen_no_part_detect
+    assign part_idx = '0;
+    assign pout_vld = pin_vld;
+    assign pin_rdy  = pout_rdy;
+    assign ptag_out = ptag_in;
+    assign part_inflight = 1'b0;
+    assign part_op = part_in_op;
+    assign part_fmt = src_fmt_i;
+    assign part_busy = 1'b0;
+  end
+
+  fpnew_pace_coeff_select #(
+    .Bounds      ( Bounds + 1     ),
+    .Degrees     ( Degrees        ),
+    .Width       ( LocalW         ),
+    .BoundStages ( BoundStages    )
+  ) i_coeff_selector (
+    .coeffs_i ( coeff_table ),
+    .bound_i  ( in_tag.part_id ),
+    .degree_i ( in_tag.degree ),
+    .coeffs_o ( coeff_pair )
+  );
+
+  fpnew_fma_multi #(
+    .FpFmtConfig (FpFmtConfig),
+    .NumPipeRegs (NumPipeRegs),
+    .PipeConfig  (PipeConfig),
+    .TagType     (fma_tag_t),
+    .AuxType     (AuxType)
+  ) i_fma_multi (
+    .clk_i,
+    .rst_ni,
+    // Input signals
+    .operands_i       ( fma_ops_in ),
+    .pace_operand_o   ( fma_bypass_op ),
+    .is_boxed_i       ( fma_is_boxed ),
+    .rnd_mode_i       ( fma_round_mode ),
+    .op_i             ( fma_op ),
+    .op_mod_i         ( fma_op_mod ),
+    .src_fmt_i        ( fma_src_fmt ),
+    .dst_fmt_i        ( fma_dst_fmt ),
+    .pace_fmt_o       ( pace_fmt ),
+    .tag_i            ( in_tag ),
+    .mask_i           ( fma_in_mask ),
+    .aux_i            ( fma_in_aux ),
+    // Input Handshake
+    .in_valid_i       ( fma_in_valid ),
+    .in_ready_o       ( fma_in_ready ),
+    .flush_i          ( fma_flush ),
+    // Output signals
+    .result_o         ( fma_res ),
+    .status_o         ( fma_status_flags ),
+    .extension_bit_o  ( fma_extension_bit ),
+    .tag_o            ( out_tag ),
+    .mask_o           ( fma_output_mask ),
+    .aux_o            ( fma_output_aux ),
+    // Output handshake
+    .out_valid_o      ( fma_vld ),
+    .out_ready_i      ( fma_rdy ),
+    // Indication of valid data in flight
+    .busy_o           ( fma_busy )
+  );
+
+endmodule

--- a/src/fpnew_pkg.sv
+++ b/src/fpnew_pkg.sv
@@ -146,11 +146,11 @@ package fpnew_pkg;
   localparam int unsigned OP_BITS = 5;
 
   typedef enum logic [OP_BITS-1:0] {
-    FMADD, FNMSUB, ADD, MUL,     // ADDMUL operation group
-    DIV, SQRT,                   // DIVSQRT operation group
-    SGNJ, MINMAX, CMP, CLASSIFY, // NONCOMP operation group
-    F2F, F2I, I2F, CPKAB, CPKCD, // CONV operation group
-    SDOTP, EXVSUM, VSUM,         // DOTP operation group
+    FMADD, FNMSUB, ADD, MUL, PWPA, PACE_INV, PACE_SQRT, PACE_RSQRT, // ADDMUL operation group
+    DIV, SQRT,                     // DIVSQRT operation group
+    SGNJ, MINMAX, CMP, CLASSIFY,   // NONCOMP operation group
+    F2F, F2I, I2F, CPKAB, CPKCD,   // CONV operation group
+    SDOTP, EXVSUM, VSUM,           // DOTP operation group
     MXDOTPF, MXDOTPI             // MXDOTP operation group
   } operation_e;
 
@@ -245,6 +245,33 @@ package fpnew_pkg;
   // same with unsigned
   typedef fmt_unsigned_t [0:NUM_OPGROUPS-1] opgrp_fmt_unsigned_t;
 
+  localparam int unsigned MAX_PACE_PARTS = 64;
+  localparam int unsigned MAX_PACE_DEGREE = 4;
+  localparam int unsigned MAX_PACE_DEGREE_BITS   = $clog2(MAX_PACE_DEGREE+1);
+  localparam int unsigned MAX_NUM_BST_STAGE = $clog2(MAX_PACE_PARTS);
+
+  typedef logic [MAX_NUM_BST_STAGE-1:0] pace_pipe_t;
+  typedef logic [MAX_PACE_DEGREE_BITS-1:0] pace_deg_t;
+
+  typedef struct packed {
+    int unsigned PaceDegree;
+    int unsigned PaceParts;
+    int unsigned PaceEps;
+    int unsigned PaceDataWidth;
+    int unsigned PaceParamWidth;
+    int unsigned PacePipeDist;
+    int unsigned FmtConfig;
+  } pace_features_t;
+
+  typedef struct packed {
+    logic inv;      // inverse of a number
+    logic sqrt; // inverse square root
+    logic rsqrt; // inverse square root
+    logic extend;   // use partial result to compute
+    logic enable;   // use partial result to compute
+    pace_deg_t degree;   // use partial result to compute
+  } pace_mode_t;
+
   // FPU configuration: features
   typedef struct packed {
     int unsigned Width;
@@ -254,6 +281,7 @@ package fpnew_pkg;
     ifmt_logic_t IntFmtMask;   // Standard INT formats for all opgroups
     fmt_logic_t  MxFpFmtMask;  // MX-specific FP formats (FP6, FP6ALT, FP4, plus FP8/FP8ALT)
     ifmt_logic_t MxIntFmtMask; // MX-specific INT formats (INT8)
+    pace_features_t PaceFeatures;
   } fpu_features_t;
 
   localparam fpu_features_t RV64D = '{
@@ -263,7 +291,8 @@ package fpnew_pkg;
     FpFmtMask:     9'b110000000,
     IntFmtMask:    4'b0011,
     MxFpFmtMask:   9'b0,         // No MX support
-    MxIntFmtMask:  4'b0
+    MxIntFmtMask:  4'b0,
+    PaceFeatures: '{default: 0}
   };
 
   localparam fpu_features_t RV32D = '{
@@ -273,7 +302,8 @@ package fpnew_pkg;
     FpFmtMask:     9'b110000000,
     IntFmtMask:    4'b0010,
     MxFpFmtMask:   9'b0,         // No MX support
-    MxIntFmtMask:  4'b0
+    MxIntFmtMask:  4'b0,
+    PaceFeatures: '{default: 0}
   };
 
   localparam fpu_features_t RV32F = '{
@@ -283,7 +313,8 @@ package fpnew_pkg;
     FpFmtMask:     9'b100000000,
     IntFmtMask:    4'b0010,
     MxFpFmtMask:   9'b0,         // No MX support
-    MxIntFmtMask:  4'b0
+    MxIntFmtMask:  4'b0,
+    PaceFeatures: '{default: 0}
   };
 
   localparam fpu_features_t RV64D_Xsflt = '{
@@ -292,6 +323,7 @@ package fpnew_pkg;
     EnableNanBox:  1'b1,
     FpFmtMask:     9'b111111000,  // Standard formats (not including FP6, FP6ALT, FP4)
     IntFmtMask:    4'b1111,
+    PaceFeatures: '{default: 0},
     MxFpFmtMask:   9'b000101111,  // MX formats: FP8, FP8ALT, FP6, FP6ALT, FP4
     MxIntFmtMask:  4'b1000        // INT8 for MX operations
   };
@@ -302,6 +334,7 @@ package fpnew_pkg;
     EnableNanBox:  1'b1,
     FpFmtMask:     9'b101111000,
     IntFmtMask:    4'b1110,
+    PaceFeatures: '{default: 0},
     MxFpFmtMask:   9'b0,         // No MX support (32-bit width insufficient)
     MxIntFmtMask:  4'b0
   };
@@ -313,7 +346,8 @@ package fpnew_pkg;
     FpFmtMask:     9'b100010000,
     IntFmtMask:    4'b0110,
     MxFpFmtMask:   9'b0,         // No MX support
-    MxIntFmtMask:  4'b0
+    MxIntFmtMask:  4'b0,
+    PaceFeatures: '{default: 0}
   };
 
 
@@ -460,13 +494,13 @@ package fpnew_pkg;
   // Returns the operation group of the given operation
   function automatic opgroup_e get_opgroup(operation_e op);
     unique case (op)
-      FMADD, FNMSUB, ADD, MUL:     return ADDMUL;
-      DIV, SQRT:                   return DIVSQRT;
-      SGNJ, MINMAX, CMP, CLASSIFY: return NONCOMP;
-      F2F, F2I, I2F, CPKAB, CPKCD: return CONV;
-      SDOTP, EXVSUM, VSUM:         return DOTP;
+      FMADD, FNMSUB, ADD, MUL, PWPA, PACE_INV, PACE_SQRT, PACE_RSQRT:  return ADDMUL;
+      DIV, SQRT:                      return DIVSQRT;
+      SGNJ, MINMAX, CMP, CLASSIFY:    return NONCOMP;
+      F2F, F2I, I2F, CPKAB, CPKCD:    return CONV;
+      SDOTP, EXVSUM, VSUM:            return DOTP;
       MXDOTPF, MXDOTPI:            return MXDOTP;
-      default:                     return NONCOMP;
+      default:                        return NONCOMP;
     endcase
   endfunction
 
@@ -508,6 +542,15 @@ package fpnew_pkg;
     for (int unsigned fmt = 0; fmt < NUM_FP_FORMATS; fmt++)
       // Mask active formats with the number of lanes for that format
       res[fmt] = cfg[fmt] & (width / fp_width(fp_format_e'(fmt)) > lane_no);
+    return res;
+  endfunction
+
+
+  function automatic fmt_logic_t get_pace_lane_formats( fmt_logic_t cfg_fpu, fmt_logic_t cfg_pace);
+    automatic fmt_logic_t res;
+    for (int unsigned fmt = 0; fmt < NUM_FP_FORMATS; fmt++)
+      // Mask active formats with the number of lanes for that format
+      res[fmt] = cfg_fpu[fmt] & cfg_pace[fmt];
     return res;
   endfunction
 

--- a/src/fpnew_top.sv
+++ b/src/fpnew_top.sv
@@ -28,7 +28,10 @@ module fpnew_top #(
   localparam int unsigned NumLanes     = fpnew_pkg::max_num_lanes(Features.Width, Features.FpFmtMask, Features.EnableVectors),
   localparam type         MaskType     = logic [NumLanes-1:0],
   localparam int unsigned WIDTH        = Features.Width,
-  localparam int unsigned NUM_OPERANDS = 3
+  localparam int unsigned NUM_OPERANDS = 3,
+  localparam fpnew_pkg::pace_features_t PaceFeatures = Features.PaceFeatures,
+  localparam int unsigned PaceParamWidth = PaceFeatures.PaceParamWidth,
+  localparam int unsigned PaceParamMsb   = (PaceParamWidth > 0) ? (PaceParamWidth - 1) : 0
 ) (
   input logic                               clk_i,
   input logic                               rst_ni,
@@ -56,7 +59,10 @@ module fpnew_top #(
   output logic                              out_valid_o,
   input  logic                              out_ready_i,
   // Indication of valid data in flight
-  output logic                              busy_o
+  output logic                              busy_o,
+  input  logic [PaceParamMsb:0]             pace_param_i,
+  input  fpnew_pkg::pace_mode_t             pace_mode_i
+
 );
 
   localparam int unsigned NUM_OPGROUPS = fpnew_pkg::NUM_OPGROUPS;
@@ -132,6 +138,7 @@ module fpnew_top #(
       .PipeConfig    ( Implementation.PipeConfig       ),
       .TagType       ( TagType                         ),
       .TrueSIMDClass ( TrueSIMDClass                   ),
+      .PaceFeatures  ( PaceFeatures                    ),
       .CompressedVecCmpResult ( CompressedVecCmpResult ),
       .StochasticRndImplementation ( StochasticRndImplementation )
     ) i_opgroup_block (
@@ -158,7 +165,10 @@ module fpnew_top #(
       .tag_o           ( opgrp_outputs[opgrp].tag    ),
       .out_valid_o     ( opgrp_out_valid[opgrp]      ),
       .out_ready_i     ( opgrp_out_ready[opgrp]      ),
-      .busy_o          ( opgrp_busy[opgrp]           )
+      .busy_o          ( opgrp_busy[opgrp]           ),
+      .pace_param_i    ( pace_param_i                ),
+      .pace_mode_i     ( pace_mode_i                 )
+
     );
   end
 

--- a/src/pace/fpnew_pace_bound_select.sv
+++ b/src/pace/fpnew_pace_bound_select.sv
@@ -1,0 +1,29 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+// Selects the bound value used by one binary-search-tree stage.
+module fpnew_pace_bound_select #(
+  parameter int unsigned Bounds   = 4,
+  parameter int unsigned Width    = 32,
+  parameter int unsigned BoundSel = Bounds == 1 ? 1 : $clog2(Bounds)
+) (
+  input  logic [Bounds-1:0][Width-1:0] bounds_i,
+  input  logic [BoundSel-1:0]          sel_i,
+  output logic [Width-1:0]             result_o
+);
+
+// Avoid indexing with a zero-width selector when only one bound exists.
+assign result_o     = Bounds == 1 ? bounds_i[0] : bounds_i[sel_i];
+
+endmodule

--- a/src/pace/fpnew_pace_cast.sv
+++ b/src/pace/fpnew_pace_cast.sv
@@ -1,0 +1,59 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+// Expands the selected input format into the shared super format.
+module fpnew_pace_cast #(
+  parameter fpnew_pkg::fmt_logic_t   FpFmtConfig   = '1,
+  localparam int unsigned            Width         = fpnew_pkg::max_fp_width(FpFmtConfig),
+  localparam fpnew_pkg::fp_encoding_t SuperFormat  = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned            NumFormats    = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned            SuperExpBits  = SuperFormat.exp_bits,
+  localparam int unsigned            SuperManBits  = SuperFormat.man_bits,
+  localparam int unsigned            SuperWidth    = 1 + SuperFormat.man_bits + SuperFormat.exp_bits
+) (
+  input logic [Width-1:0]            operand_i,
+  input fpnew_pkg::fp_format_e       src_fmt_i,
+  output logic [SuperWidth-1:0]      result_o
+);
+
+  logic [NumFormats-1:0]                    fmt_sign;
+  logic [NumFormats-1:0][SuperManBits-1:0]  fmt_mantissa;
+  logic [NumFormats-1:0][SuperExpBits-1:0]  fmt_exponent;
+
+  for (genvar fmt = 0; fmt < int'(NumFormats); fmt++) begin : gen_fmt_init_inputs
+    localparam int unsigned FpWidth = fpnew_pkg::fp_width(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ExpBits = fpnew_pkg::exp_bits(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ManBits = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ExpDiff = SuperExpBits - ExpBits;
+    localparam int unsigned ManDiff = SuperManBits - ManBits;
+
+    if (FpFmtConfig[fmt]) begin : gen_active_format
+      assign fmt_sign[fmt] = operand_i[FpWidth-1];
+      // Smaller formats reuse the super-format exponent width by sign-extending the exponent field.
+      assign fmt_exponent[fmt] = ExpDiff > 0
+          ? {{ExpDiff{1'b1}}, operand_i[ManBits+:ExpBits]}
+          : operand_i[ManBits+:ExpBits];
+      assign fmt_mantissa[fmt] = ManDiff > 0
+          ? {{ManDiff{1'b0}}, operand_i[0+:ManBits]}
+          : operand_i[0+:ManBits];
+    end else begin : gen_inactive_format
+      assign fmt_sign[fmt]     = fpnew_pkg::DONT_CARE;
+      assign fmt_exponent[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_mantissa[fmt] = '{default: fpnew_pkg::DONT_CARE};
+    end
+  end
+
+  assign result_o = {fmt_sign[src_fmt_i], fmt_exponent[src_fmt_i], fmt_mantissa[src_fmt_i]};
+
+endmodule

--- a/src/pace/fpnew_pace_cmp.sv
+++ b/src/pace/fpnew_pace_cmp.sv
@@ -1,0 +1,147 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+// Compares two super-format operands and optionally pipelines the result.
+module fpnew_pace_cmp #(
+  parameter fpnew_pkg::fmt_logic_t    FpFmtConfig  = '1,
+  parameter int unsigned              NumPipeRegs  = 0,
+  parameter fpnew_pkg::pipe_config_t  PipeConfig   = fpnew_pkg::BEFORE,
+  parameter type                      TagType      = logic,
+  parameter type                      AuxType      = logic,
+  localparam fpnew_pkg::fp_encoding_t SuperFormat = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned             SuperExpBits = SuperFormat.exp_bits,
+  localparam int unsigned             SuperManBits = SuperFormat.man_bits,
+  localparam int unsigned             SuperWidth   = 1 + SuperFormat.man_bits + SuperFormat.exp_bits
+) (
+  input logic [1:0][SuperWidth-1:0] operands_i,
+  output logic [SuperWidth-1:0]     operand_o,
+  input logic                       clk_i,
+  input logic                       rst_ni,
+  input TagType                     tag_i,
+  input logic                       in_valid_i,
+  output logic                      in_ready_o,
+  input logic                       flush_i,
+  output logic                      result_o,
+  output TagType                    tag_o,
+  output logic                      out_valid_o,
+  input logic                       out_ready_i,
+  output logic                      busy_o
+);
+
+  localparam int unsigned NumInpRegs = (PipeConfig == fpnew_pkg::BEFORE
+                                     || PipeConfig == fpnew_pkg::INSIDE)
+                                       ? NumPipeRegs
+                                       : (PipeConfig == fpnew_pkg::DISTRIBUTED)
+                                           ? ((NumPipeRegs + 1) / 2)
+                                           : 0;
+  localparam int unsigned NumOutRegs = (PipeConfig == fpnew_pkg::AFTER)
+                                       ? NumPipeRegs
+                                       : (PipeConfig == fpnew_pkg::DISTRIBUTED)
+                                           ? (NumPipeRegs / 2)
+                                           : 0;
+
+  typedef struct packed {
+    logic                    sign;
+    logic [SuperExpBits-1:0] exponent;
+    logic [SuperManBits-1:0] mantissa;
+  } fp_t;
+
+  // Input pipeline.
+  logic [1:0][SuperWidth-1:0] inp_pipe_operands_q [NumInpRegs+1];
+  TagType                     inp_pipe_tag_q      [NumInpRegs+1];
+  logic                       inp_pipe_valid_q    [NumInpRegs+1];
+  logic                       inp_pipe_ready      [NumInpRegs+1];
+  logic                       inp_pipe_reg_ena    [NumInpRegs > 0 ? NumInpRegs : 1];
+  logic [NumInpRegs:0]        inp_pipe_valid_vec;
+
+  assign inp_pipe_operands_q[0] = operands_i;
+  assign inp_pipe_tag_q[0]      = tag_i;
+  assign inp_pipe_valid_q[0]    = in_valid_i;
+  assign in_ready_o             = inp_pipe_ready[0];
+
+  for (genvar i = 0; i < NumInpRegs; i++) begin : gen_input_pipeline
+    assign inp_pipe_ready[i] = inp_pipe_ready[i+1] | ~inp_pipe_valid_q[i+1];
+    `FFLARNC(
+        inp_pipe_valid_q[i+1],
+        inp_pipe_valid_q[i],
+        inp_pipe_ready[i],
+        flush_i,
+        1'b0,
+        clk_i,
+        rst_ni
+    )
+    assign inp_pipe_reg_ena[i] = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+
+    `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], inp_pipe_reg_ena[i], '0)
+    `FFL(inp_pipe_tag_q[i+1],      inp_pipe_tag_q[i],      inp_pipe_reg_ena[i], TagType'('0))
+  end
+
+  fp_t operand_a, operand_b;
+  logic result_d;
+
+  assign operand_a = inp_pipe_operands_q[NumInpRegs][0];
+  assign operand_b = inp_pipe_operands_q[NumInpRegs][1];
+  assign result_d  = (operand_a == operand_b) ? 1'b0
+                    : (operand_a > operand_b) ^ (operand_a.sign || operand_b.sign);
+
+  // Output pipeline.
+  fp_t    out_pipe_operand_q [NumOutRegs+1];
+  logic   out_pipe_result_q  [NumOutRegs+1];
+  TagType out_pipe_tag_q     [NumOutRegs+1];
+  logic   out_pipe_valid_q   [NumOutRegs+1];
+  logic   out_pipe_ready     [NumOutRegs+1];
+  logic   out_pipe_reg_ena   [NumOutRegs > 0 ? NumOutRegs : 1];
+  logic [NumOutRegs:0]       out_pipe_valid_vec;
+
+  assign out_pipe_result_q[0]  = result_d;
+  assign out_pipe_operand_q[0] = operand_a;
+  assign out_pipe_tag_q[0]     = inp_pipe_tag_q[NumInpRegs];
+  assign out_pipe_valid_q[0]   = inp_pipe_valid_q[NumInpRegs];
+  assign inp_pipe_ready[NumInpRegs] = out_pipe_ready[0];
+
+  for (genvar i = 0; i < NumOutRegs; i++) begin : gen_output_pipeline
+    assign out_pipe_ready[i]   = out_pipe_ready[i+1] | ~out_pipe_valid_q[i+1];
+    assign out_pipe_reg_ena[i] = out_pipe_ready[i] & out_pipe_valid_q[i];
+    `FFLARNC(
+        out_pipe_valid_q[i+1],
+        out_pipe_valid_q[i],
+        out_pipe_ready[i],
+        flush_i,
+        1'b0,
+        clk_i,
+        rst_ni
+    )
+    `FFL(out_pipe_result_q[i+1],  out_pipe_result_q[i],  out_pipe_reg_ena[i], '0)
+    `FFL(out_pipe_operand_q[i+1], out_pipe_operand_q[i], out_pipe_reg_ena[i], '0)
+    `FFL(out_pipe_tag_q[i+1],     out_pipe_tag_q[i],     out_pipe_reg_ena[i], TagType'('0))
+  end
+
+  for (genvar i = 0; i <= NumInpRegs; i++) begin : gen_inp_valid_vec
+    assign inp_pipe_valid_vec[i] = inp_pipe_valid_q[i];
+  end
+
+  for (genvar i = 0; i <= NumOutRegs; i++) begin : gen_out_valid_vec
+    assign out_pipe_valid_vec[i] = out_pipe_valid_q[i];
+  end
+
+  assign out_pipe_ready[NumOutRegs] = out_ready_i;
+  assign result_o    = out_pipe_result_q[NumOutRegs];
+  assign operand_o   = out_pipe_operand_q[NumOutRegs];
+  assign tag_o       = out_pipe_tag_q[NumOutRegs];
+  assign out_valid_o = out_pipe_valid_q[NumOutRegs];
+  assign busy_o      = |inp_pipe_valid_vec | |out_pipe_valid_vec;
+endmodule

--- a/src/pace/fpnew_pace_coeff_select.sv
+++ b/src/pace/fpnew_pace_coeff_select.sv
@@ -1,0 +1,33 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+
+// Selects the constant and degree-specific coefficients for one partition.
+module fpnew_pace_coeff_select #(
+  parameter int unsigned Bounds      = 7,
+  parameter int unsigned Degrees     = 2,
+  parameter int unsigned Width       = 32,
+  parameter int unsigned BoundStages = $clog2(Bounds),
+  parameter int unsigned DegreesBits = $clog2(Degrees + 1)
+) (
+  input  logic [Degrees:0][Bounds-1:0][Width-1:0] coeffs_i,
+  input  logic [BoundStages-1:0]                  bound_i,
+  input  logic [DegreesBits-1:0]                  degree_i,
+  output logic [1:0][Width-1:0]                   coeffs_o
+);
+
+  assign coeffs_o[0] = coeffs_i[0][bound_i];
+  assign coeffs_o[1] = coeffs_i[degree_i][bound_i];
+
+endmodule

--- a/src/pace/fpnew_pace_decast.sv
+++ b/src/pace/fpnew_pace_decast.sv
@@ -1,0 +1,55 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+// Narrows the shared super format back to the selected destination format.
+module fpnew_pace_decast #(
+  parameter fpnew_pkg::fmt_logic_t   FpFmtConfig    = '1,
+  localparam int unsigned            Width          = fpnew_pkg::max_fp_width(FpFmtConfig),
+  localparam fpnew_pkg::fp_encoding_t SuperFormat   = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned            NumFormats     = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned            SuperExpBits   = SuperFormat.exp_bits,
+  localparam int unsigned            SuperManBits   = SuperFormat.man_bits,
+  localparam int unsigned            SuperWidth     = 1 + SuperFormat.man_bits + SuperFormat.exp_bits
+) (
+  input logic [SuperWidth-1:0] operand_i,
+  input fpnew_pkg::fp_format_e src_fmt_i,
+  output logic [Width-1:0]     result_o
+);
+
+  logic [NumFormats-1:0]                   fmt_sign;
+  logic [NumFormats-1:0][SuperManBits-1:0] fmt_mantissa;
+  logic [NumFormats-1:0][SuperExpBits-1:0] fmt_exponent;
+  logic [NumFormats-1:0][Width-1:0]        fmt_operand;
+
+  for (genvar fmt = 0; fmt < int'(NumFormats); fmt++) begin : gen_fmt_init_inputs
+    localparam int unsigned ExpBits = fpnew_pkg::exp_bits(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ManBits = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
+
+    if (FpFmtConfig[fmt]) begin : gen_active_format
+      assign fmt_sign[fmt]     = operand_i[SuperWidth-1];
+      assign fmt_exponent[fmt] = operand_i[SuperManBits+:ExpBits];
+      assign fmt_mantissa[fmt] = operand_i[0+:ManBits];
+      assign fmt_operand[fmt]  = {fmt_sign[fmt], fmt_exponent[fmt][0+:ExpBits],
+                                  fmt_mantissa[fmt][0+:ManBits]};
+    end else begin : gen_inactive_format
+      assign fmt_sign[fmt]     = fpnew_pkg::DONT_CARE;
+      assign fmt_exponent[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_mantissa[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_operand[fmt]  = '{default: fpnew_pkg::DONT_CARE};
+    end
+  end
+
+  assign result_o = fmt_operand[src_fmt_i];
+
+endmodule

--- a/src/pace/fpnew_pace_frexp.sv
+++ b/src/pace/fpnew_pace_frexp.sv
@@ -1,0 +1,138 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+// Extracts exponent metadata and prepares a range-reduced operand for PACE modes.
+module fpnew_pace_frexp #(
+  parameter fpnew_pkg::fmt_logic_t    FpFmtConfig  = '1,
+  parameter type                      FrexpInfoType = logic,
+  localparam fpnew_pkg::fp_encoding_t SuperFormat = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned             Width        = fpnew_pkg::max_fp_width(FpFmtConfig),
+  localparam int unsigned             NumFormats   = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned             SuperExpBits = SuperFormat.exp_bits,
+  localparam int unsigned             SuperManBits = SuperFormat.man_bits,
+  localparam int unsigned             SuperWidth   = 1 + SuperFormat.man_bits + SuperFormat.exp_bits
+) (
+  input  logic                  clk_i,
+  input  logic                  rst_ni,
+  input  fpnew_pkg::fp_format_e src_fmt_i,
+  input  fpnew_pkg::pace_mode_t pace_mode_i,
+  input  logic [Width-1:0]      eps_i,
+  input  logic [Width-1:0]      operand_i,
+  output logic [Width-1:0]      operand_o,
+  output FrexpInfoType          frexp_info_o
+);
+
+  logic                                    lt_eps;
+  logic [NumFormats-1:0]                   fmt_sign;
+  logic [NumFormats-1:0][SuperManBits-1:0] fmt_mantissa;
+  logic [NumFormats-1:0][SuperExpBits-1:0] fmt_exponent;
+  logic [NumFormats-1:0][SuperExpBits-1:0] fmt_bias;
+
+  logic [SuperExpBits:0]                unbiased_exponent;
+  logic [SuperExpBits-1:0]              pace_exponent;
+  logic [SuperExpBits-1:0]              adjusted_exponent;
+
+  logic [NumFormats-1:0][SuperWidth-1:0] fmt_pace_operand;
+
+  // Extract each enabled format and rebuild it in the shared super format.
+  for (genvar fmt = 0; fmt < int'(NumFormats); fmt++) begin : gen_fmt_init_inputs
+    localparam int unsigned FpWidth = fpnew_pkg::fp_width(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ExpBits = fpnew_pkg::exp_bits(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ManBits = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned FpBias  = fpnew_pkg::bias(fpnew_pkg::fp_format_e'(fmt));
+
+    if (FpFmtConfig[fmt]) begin : gen_active_format
+      assign fmt_sign[fmt]     = operand_i[FpWidth-1];
+      assign fmt_mantissa[fmt] = operand_i[0+:ManBits];
+      assign fmt_exponent[fmt] = operand_i[ManBits+:ExpBits];
+      assign fmt_bias[fmt]     = FpBias;
+
+      if (FpWidth < Width) begin : gen_narrow_format
+        assign fmt_pace_operand[fmt] = {
+            {(Width-FpWidth){1'b0}},
+            1'b0,
+            pace_exponent[0+:ExpBits],
+            fmt_mantissa[fmt][0+:ManBits]
+        };
+      end else begin : gen_wide_format
+        assign fmt_pace_operand[fmt] = {
+            1'b0,
+            pace_exponent[0+:ExpBits],
+            fmt_mantissa[fmt][0+:ManBits]
+        };
+      end
+    end else begin : gen_inactive_format
+      assign fmt_bias[fmt]     = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_sign[fmt]     = fpnew_pkg::DONT_CARE;
+      assign fmt_exponent[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_mantissa[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_pace_operand[fmt] = '{default: fpnew_pkg::DONT_CARE};
+    end
+  end
+
+  // Extract the exponent term that downstream PACE stages consume.
+  assign unbiased_exponent = {1'b0, fmt_exponent[src_fmt_i]} - fmt_bias[src_fmt_i];
+  assign pace_exponent     = pace_mode_i.inv
+                           ? fmt_bias[src_fmt_i]
+                           : (pace_mode_i.sqrt | pace_mode_i.rsqrt)
+                               ? fmt_bias[src_fmt_i] + unbiased_exponent[0]
+                               : fmt_exponent[src_fmt_i];
+  assign adjusted_exponent = pace_mode_i.inv
+                           ? unbiased_exponent
+                           : (unbiased_exponent - unbiased_exponent[0]) >> 1;
+
+  assign operand_o = fmt_pace_operand[src_fmt_i];
+
+  // Compare operand magnitude against epsilon in super format.
+  logic [1:0][SuperWidth-1:0] sfmt_cmp_operand;
+  logic [SuperWidth-1:0]      sfmt_operand;
+
+  assign sfmt_cmp_operand[1] = {1'b0, sfmt_operand[0+:SuperWidth-1]};
+  assign sfmt_cmp_operand[0] = eps_i;
+
+  fpnew_pace_cast #(
+    .FpFmtConfig(FpFmtConfig)
+  ) i_pace_ldcast (
+    .operand_i,
+    .src_fmt_i,
+    .result_o(sfmt_operand)
+  );
+
+  fpnew_pace_cmp #(
+    .FpFmtConfig(FpFmtConfig)
+  ) i_eps_cmp (
+    .clk_i,
+    .rst_ni,
+    .operands_i ( sfmt_cmp_operand ),
+    .operand_o  (),
+    .tag_i      ( 1'b0 ),
+    .in_valid_i ( 1'b1 ),
+    .in_ready_o (),
+    .flush_i    ( 1'b0 ),
+    .result_o   ( lt_eps ),
+    .tag_o      (),
+    .out_valid_o (),
+    .out_ready_i ( 1'b1 ),
+    .busy_o     ()
+  );
+
+  assign frexp_info_o.inv        = pace_mode_i.inv;
+  assign frexp_info_o.sqrt       = pace_mode_i.sqrt;
+  assign frexp_info_o.rsqrt      = pace_mode_i.rsqrt;
+  assign frexp_info_o.exponent   = adjusted_exponent;
+  assign frexp_info_o.sign       = fmt_sign[src_fmt_i];
+  assign frexp_info_o.lt_eps = lt_eps
+                                 & (pace_mode_i.inv | pace_mode_i.sqrt | pace_mode_i.rsqrt);
+
+endmodule

--- a/src/pace/fpnew_pace_ldexp.sv
+++ b/src/pace/fpnew_pace_ldexp.sv
@@ -1,0 +1,91 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+
+// Restores the scaled result back into the selected floating-point format.
+module fpnew_pace_ldexp #(
+  parameter fpnew_pkg::fmt_logic_t    FpFmtConfig  = '1,
+  localparam fpnew_pkg::fp_encoding_t SuperFormat = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned             Width       = fpnew_pkg::max_fp_width(FpFmtConfig),
+  localparam int unsigned             NumFormats  = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned             SuperExpBits = SuperFormat.exp_bits,
+  localparam int unsigned             SuperManBits = SuperFormat.man_bits,
+  localparam int unsigned             SuperWidth   = 1 + SuperFormat.man_bits
+                                                        + SuperFormat.exp_bits
+) (
+  input  fpnew_pkg::fp_format_e src_fmt_i,
+  input  logic                  pace_op_i,
+  input  logic                  op_inv_i,
+  input  logic                  op_sqrt_i,
+  input  logic                  op_rsqrt_i,
+  input  logic                  lt_eps_i,
+  input  logic [Width-1:0]      operand_i,
+  input  logic [Width-1:0]      eps_val_i,
+  input  logic [SuperExpBits-1:0] exponent_i,
+  input  logic                  sign_i,
+  output logic [Width-1:0]      operand_o
+);
+
+  logic [NumFormats-1:0]                   fmt_sign;
+  logic [NumFormats-1:0][SuperManBits-1:0] fmt_mantissa;
+  logic [NumFormats-1:0][SuperExpBits-1:0] fmt_exponent;
+  logic [NumFormats-1:0][Width-1:0]        fmt_operand;
+
+  logic inv_sqrt_op;
+  logic sqrt_op;
+
+  assign inv_sqrt_op = pace_op_i & (op_inv_i | op_sqrt_i | op_rsqrt_i);
+  assign sqrt_op     = pace_op_i & op_sqrt_i;
+
+  // Re-encode the scaled result into the selected destination format.
+  for (genvar fmt = 0; fmt < int'(NumFormats); fmt++) begin : gen_fmt_outputs
+    localparam int unsigned FpWidth = fpnew_pkg::fp_width(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ExpBits = fpnew_pkg::exp_bits(fpnew_pkg::fp_format_e'(fmt));
+    localparam int unsigned ManBits = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
+
+    if (FpFmtConfig[fmt]) begin : gen_active_format
+      assign fmt_sign[fmt]     = inv_sqrt_op ? sign_i : operand_i[FpWidth-1];
+      assign fmt_mantissa[fmt] = operand_i[0+:ManBits];
+      assign fmt_exponent[fmt] = sqrt_op
+                               ? operand_i[ManBits+:ExpBits] + exponent_i[0+:ExpBits]
+                               : inv_sqrt_op
+                                   ? operand_i[ManBits+:ExpBits] - exponent_i[0+:ExpBits]
+                                   : operand_i[ManBits+:ExpBits];
+
+      if (FpWidth < Width) begin : gen_narrow_format
+        assign fmt_operand[fmt] = {
+            {(Width - FpWidth){1'b0}},
+            fmt_sign[fmt],
+            fmt_exponent[fmt][ExpBits-1:0],
+            fmt_mantissa[fmt][ManBits-1:0]
+        };
+      end else begin : gen_wide_format
+        assign fmt_operand[fmt] = {
+            fmt_sign[fmt],
+            fmt_exponent[fmt][ExpBits-1:0],
+            fmt_mantissa[fmt][ManBits-1:0]
+        };
+      end
+    end else begin : gen_inactive_format
+      assign fmt_sign[fmt]     = fpnew_pkg::DONT_CARE;
+      assign fmt_exponent[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_mantissa[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_operand[fmt]  = '0;
+    end
+  end
+
+  assign operand_o = lt_eps_i ? {sign_i, eps_val_i[Width-2:0]}
+                                  : fmt_operand[src_fmt_i];
+
+endmodule

--- a/src/pace/fpnew_pace_partition.sv
+++ b/src/pace/fpnew_pace_partition.sv
@@ -1,0 +1,194 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
+
+// Traverses the partition tree and returns the selected bound index.
+module fpnew_pace_partition #(
+  parameter fpnew_pkg::fmt_logic_t    FpFmtConfig  = '1,
+  parameter int unsigned              NumPipeRegs  = 0,
+  parameter fpnew_pkg::pipe_config_t  PipeConfig   = fpnew_pkg::BEFORE,
+  parameter type                      TagType      = logic,
+  parameter type                      AuxType      = logic,
+  parameter int unsigned              Bounds       = 7,
+  parameter int unsigned              NumCmpStages = $clog2(Bounds),
+  parameter fpnew_pkg::pace_pipe_t    PipeRegs     = '0,
+  localparam fpnew_pkg::fp_encoding_t SuperFormat = fpnew_pkg::super_format(FpFmtConfig),
+  localparam int unsigned             Width        = fpnew_pkg::max_fp_width(FpFmtConfig),
+  localparam int unsigned             SuperWidth   = 1 + SuperFormat.man_bits + SuperFormat.exp_bits
+) (
+  input  logic                              clk_i,
+  input  logic                              rst_ni,
+  input  logic [Bounds-1:0][SuperWidth-1:0] bounds_i,
+  input  logic [Width-1:0]                  operand_i,
+  output logic [Width-1:0]                  operand_o,
+  input  fpnew_pkg::fp_format_e             src_fmt_i,
+  output fpnew_pkg::fp_format_e dst_fmt_o,
+  input  TagType                            tag_i,
+  input  logic                              in_valid_i,
+  output logic                              in_ready_o,
+  output logic [NumCmpStages-1:0]           bound_id_o,
+  output TagType                            tag_o,
+  output logic                              out_valid_o,
+  input  logic                              out_ready_i,
+  output logic                              inflight_o,
+  output logic                              busy_o
+);
+  // ----------------
+  // Type Definitions
+  // ----------------
+  typedef struct packed {
+    TagType tag;
+    logic [NumCmpStages-1:0] bound_id;
+    fpnew_pkg::fp_format_e src_fmt;
+  } part_tag_t;
+
+  // ----------------
+  // Local Constants
+  // ----------------
+  localparam int unsigned MaxBoundsPerStage = 1 << (NumCmpStages - 1);
+  localparam int unsigned LastCmpStage      = NumCmpStages - 1;
+
+  // -----------------
+  // Stage Bookkeeping
+  // -----------------
+  part_tag_t [NumCmpStages-1:0]                              stage_tag_in;
+  part_tag_t [NumCmpStages-1:0]                              stage_tag_out;
+
+  logic [NumCmpStages:0][SuperWidth-1:0]                     stage_probe_operand;
+  logic [NumCmpStages-1:0][MaxBoundsPerStage-1:0][SuperWidth-1:0] stage_bounds;
+  logic [NumCmpStages-1:0][1:0][SuperWidth-1:0]              stage_cmp_operands;
+  logic [NumCmpStages-1:0][SuperWidth-1:0]                   stage_output_operand;
+  logic [NumCmpStages-1:0]                                   stage_compare_result;
+  logic [NumCmpStages:0]                                     stage_sel;
+  logic [NumCmpStages-1:0]                                   stage_in_valid;
+  logic [NumCmpStages-1:0]                                   stage_in_ready;
+  logic [NumCmpStages-1:0]                                   stage_out_valid;
+  logic [NumCmpStages-1:0]                                   stage_out_ready;
+  logic [NumCmpStages-1:0][SuperWidth-1:0]                   stage_selected_bound;
+  logic [NumCmpStages-1:0]                                   stage_busy;
+  logic [NumCmpStages-1:0]                                   stage_busy_vec;
+  logic [NumCmpStages-1:0][NumCmpStages-1:0]                 stage_next_bound_id;
+  logic [SuperWidth-1:0]                                     super_operand_in;
+  logic [SuperWidth-1:0]                                     super_operand_out;
+
+  // ----------------
+  // Top-Level Wiring
+  // ----------------
+  for (genvar stage = 0; stage < NumCmpStages; stage++) begin : gen_busy_vec
+    assign stage_busy_vec[stage] = stage_busy[stage];
+  end
+
+  assign busy_o                 = |stage_busy_vec;
+  assign inflight_o             = busy_o | out_valid_o;
+  assign dst_fmt_o              = stage_tag_out[LastCmpStage].src_fmt;
+  assign stage_probe_operand[0] = super_operand_in;
+  assign super_operand_out      = stage_probe_operand[NumCmpStages];
+
+  fpnew_pace_cast #(
+    .FpFmtConfig(FpFmtConfig)
+  ) i_input_cast (
+    .operand_i(operand_i),
+    .src_fmt_i(src_fmt_i),
+    .result_o(super_operand_in)
+  );
+
+  fpnew_pace_decast #(
+    .FpFmtConfig(FpFmtConfig)
+  ) i_output_cast (
+    .operand_i(super_operand_out),
+    .src_fmt_i(stage_tag_out[LastCmpStage].src_fmt),
+    .result_o(operand_o)
+  );
+
+  assign stage_out_ready[LastCmpStage] = out_ready_i;
+  assign out_valid_o                   = stage_out_valid[LastCmpStage];
+  assign in_ready_o                    = stage_in_ready[0];
+
+  for (genvar stage = 0; stage < NumCmpStages; stage++) begin : gen_tag_flow
+    localparam int unsigned StageSelIdx = NumCmpStages - stage + 1;
+    localparam int unsigned BoundBitIdx = NumCmpStages - stage;
+
+    assign stage_tag_in[stage].tag = (stage == 0) ? tag_i : stage_tag_out[stage-1].tag;
+    assign stage_tag_in[stage].src_fmt = (stage == 0) ? src_fmt_i
+                                                      : stage_tag_out[stage-1].src_fmt;
+    assign stage_next_bound_id[stage] = (stage == 0)
+        ? '0
+        : stage_tag_out[stage-1].bound_id |
+            ({{(NumCmpStages-1){1'b0}}, stage_sel[StageSelIdx]} << BoundBitIdx);
+    assign stage_tag_in[stage].bound_id = stage_next_bound_id[stage];
+  end
+
+  assign tag_o      = stage_tag_out[LastCmpStage].tag;
+  assign bound_id_o = stage_tag_out[LastCmpStage].bound_id |
+                      {{(NumCmpStages-1){1'b0}}, stage_sel[1]};
+
+  for (genvar stage = 0; stage < NumCmpStages; stage++) begin : gen_stages
+    localparam int unsigned NumBounds     = 1 << stage;
+    localparam int unsigned BoundSelWidth = NumBounds == 1 ? 1 : $clog2(NumBounds);
+    localparam int unsigned StageSelIdx   = NumCmpStages - stage;
+
+    for (genvar bound = 0; bound < NumBounds; bound++) begin : gen_bounds
+      localparam int unsigned BoundIdx = NumBounds - 1 + bound;
+
+      // Stage ordering follows the binary-search-tree layout.
+      assign stage_bounds[stage][bound] = bounds_i[BoundIdx];
+    end
+
+    assign stage_in_valid[stage] = (stage == 0) ? in_valid_i : stage_out_valid[stage-1];
+
+    if (stage < LastCmpStage) begin : gen_stage_ready
+      assign stage_out_ready[stage] = stage_in_ready[stage+1];
+    end
+
+    fpnew_pace_bound_select #(
+      .Bounds(NumBounds),
+      .Width(SuperWidth)
+    ) i_pace_bound_selector (
+      .bounds_i(stage_bounds[stage][0+:NumBounds]),
+      .sel_i(
+        (stage == 0)
+          ? BoundSelWidth'('0)
+          : stage_tag_in[stage].bound_id[NumCmpStages-1-:BoundSelWidth]
+      ),
+      .result_o(stage_selected_bound[stage])
+    );
+
+    assign stage_cmp_operands[stage][0]   = stage_probe_operand[stage];
+    assign stage_cmp_operands[stage][1]   = stage_selected_bound[stage];
+    assign stage_probe_operand[stage + 1] = stage_output_operand[stage];
+    assign stage_sel[StageSelIdx]         = stage_compare_result[stage];
+
+    fpnew_pace_cmp #(
+      .FpFmtConfig (FpFmtConfig),
+      .NumPipeRegs (PipeRegs[stage]),
+      .PipeConfig  (PipeConfig),
+      .TagType     (part_tag_t)
+    ) i_pace_gt_cmp (
+      .clk_i      (clk_i),
+      .rst_ni     (rst_ni),
+      .operands_i (stage_cmp_operands[stage]),
+      .operand_o  (stage_output_operand[stage]),
+      .tag_i      (stage_tag_in[stage]),
+      .in_valid_i (stage_in_valid[stage]),
+      .in_ready_o (stage_in_ready[stage]),
+      .flush_i    (1'b0),
+      .result_o   (stage_compare_result[stage]),
+      .tag_o      (stage_tag_out[stage]),
+      .out_valid_o(stage_out_valid[stage]),
+      .out_ready_i(stage_out_ready[stage]),
+      .busy_o     (stage_busy[stage])
+    );
+  end
+
+endmodule


### PR DESCRIPTION
PACE (Piecewise Polynomial Approximation Compute Engine) implements nonlinear function approximation using piecewise polynomials on top of the existing FMA and loopback paths.

It supports SIMD-style execution for FP32 and FP16/BF16 formats. Higher-degree execution is performed through loopback across multiple cycles.

This commit adds:
- PACE control and datapath integration
- PACE-specific helper modules
- support logic for cast, decast, compare, and ldexp
- parameters for degree, partitions, pipeline stages and datatype