### PR TITLE
Fix MXDOTP two’s-complement LSB under right-shift + sticky

### DIFF
--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -724,6 +724,7 @@ module fpnew_mxdotp_twos_compl
   input  logic accumulator_is_right_shifted,
   input  logic signed [9:0] accumulator_right_shift_amount,
   input  logic final_sign,
+  input  logic accumulator_sticky,
   // Output signals
   output logic [LZC_SUM_WIDTH-1:0] sum_magnitude
 );
@@ -734,7 +735,7 @@ module fpnew_mxdotp_twos_compl
   always_comb begin : get_twos_complement
     if (final_sign) begin
       sum_magnitude = ~sum_product_accumulator_extended + 1;
-      if (accumulator_is_right_shifted && accumulator_right_shift_amount > DST_PRECISION_BITS && signed_mantissa_d != 0) begin
+      if (accumulator_is_right_shifted && accumulator_right_shift_amount > DST_PRECISION_BITS && signed_mantissa_d != 0 && accumulator_sticky) begin
         sum_magnitude = ~sum_product_accumulator_extended;
       end
     end else begin
@@ -808,6 +809,7 @@ module fpnew_mxdotp_normalizer
     .signed_mantissa_d               ( signed_mantissa_d               ),
     .accumulator_is_right_shifted    ( accumulator_is_right_shifted    ),
     .accumulator_right_shift_amount  ( accumulator_right_shift_amount  ),
+    .accumulator_sticky              ( accumulator_sticky              ),
     .sum_magnitude( sum_magnitude                  )
   );
 


### PR DESCRIPTION
- Fixes an edge-case in the MXDOTP two’s-complement path when the accumulator is right-shifted.
- Propagates and uses accumulator_sticky so the “LSB correction” only triggers when there’s actually sticky information; this avoids an off-by-one magnitude mistake for negative results in that corner case.