### PR TITLE
:bug: Fix fdiv/fsqrt directed rounding in the legacy divsqrt unit

### DIFF
--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -278,6 +278,22 @@ module fpnew_divsqrt_multi #(
   fpnew_pkg::status_t unit_status, held_status_q;
   logic               hold_en;
 
+  // Translate the fpnew RISC-V roundmode encoding into the legacy PULP
+  // div_sqrt_top_mvp RM_SI encoding. Nearest-even and truncate agree, but
+  // round-down and round-up are swapped, and the legacy unit has no
+  // ties-to-max mode, so map it to nearest-even.
+  logic [2:0] divsqrt_rm;
+  always_comb begin
+    unique case (rnd_mode_q)
+      fpnew_pkg::RNE: divsqrt_rm = 3'h0;
+      fpnew_pkg::RTZ: divsqrt_rm = 3'h1;
+      fpnew_pkg::RDN: divsqrt_rm = 3'h3;
+      fpnew_pkg::RUP: divsqrt_rm = 3'h2;
+      fpnew_pkg::RMM: divsqrt_rm = 3'h0;
+      default:        divsqrt_rm = 3'h0;
+    endcase
+  end
+
   div_sqrt_top_mvp i_divsqrt_lei (
    .Clk_CI           ( clk_i               ),
    .Rst_RBI          ( rst_ni              ),
@@ -285,7 +301,7 @@ module fpnew_divsqrt_multi #(
    .Sqrt_start_SI    ( sqrt_valid          ),
    .Operand_a_DI     ( divsqrt_operands[0] ),
    .Operand_b_DI     ( divsqrt_operands[1] ),
-   .RM_SI            ( rnd_mode_q          ),
+   .RM_SI            ( divsqrt_rm          ),
    .Precision_ctl_SI ( '0                  ),
    .Format_sel_SI    ( divsqrt_fmt         ),
    .Kill_SI          ( flush_i             ),


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

fpnew_divsqrt_multi drives the legacy PULP div_sqrt_top_mvp unit and passes the
instruction's rounding mode straight to its RM_SI port, but the two use different
encodings. Round-to-nearest-even and round-toward-zero agree, but round-down and
round-up are swapped (RM_SI 2 is toward +inf, 3 is toward -inf), and
round-to-nearest-ties-to-max has no case and falls through to truncate. So fdiv
and fsqrt round one ulp the wrong way under the directed modes, for single and
double precision.

The fix translates the mode into the divsqrt encoding before driving RM_SI
(round-down to 3, round-up to 2, ties-to-max to nearest since the legacy unit has
no ties-to-max mode). Round-to-nearest-even and round-toward-zero are unchanged.

Note: this fixes the round-down / round-up swap at the cvfpu wrapper by translating the mode before RM_SI. pulp-platform/fpu_div_sqrt_mvp/pull/20 fixes the same swap at its source (and also the overflow case). Only one should land, since applying both swaps the modes twice and brings the bug back.