### PR TITLE
MXDOTP updates for MXCore

### DIFF
--- a/src/fpnew_mxdotp_multi.sv
+++ b/src/fpnew_mxdotp_multi.sv
@@ -22,6 +22,7 @@ module fpnew_mxdotp_multi
   parameter fpnew_pkg::fmt_logic_t   FpSrcFmtConfig  = MxdotpSrcFpFmtConfig,
   parameter fpnew_pkg::ifmt_logic_t  IntSrcFmtConfig = MxdotpSrcIntFmtConfig,
   parameter fpnew_pkg::fmt_logic_t   FpDstFmtConfig  = MxdotpDstFpFmtConfig,
+  parameter int unsigned             LaneWidth   = 64,
   parameter int unsigned             VectorSize  = 8,
   parameter int unsigned             NumPipeRegs = 4,
   parameter fpnew_pkg::pipe_config_t PipeConfig  = fpnew_pkg::BEFORE,
@@ -67,6 +68,10 @@ module fpnew_mxdotp_multi
   output logic                        busy_o
 );
 
+  if (LaneWidth != VectorSize*SRC_WIDTH) begin
+    $fatal(1, "MXDOTP requires LaneWidth to be VectorSize*SRC_WIDTH, got LaneWidth=%0d and VectorSize=%0d", LaneWidth, VectorSize);
+  end
+
   // ----------------
   // Pipeline stages
   // ----------------
@@ -105,7 +110,7 @@ module fpnew_mxdotp_multi
   // -----------------------------------------
   // Computed from module parameters instead of package constants
   localparam int unsigned FP6_VECTOR_SIZE = ((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ?
-                                            (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ? cf_math_pkg::ceil_div(VectorSize * SRC_WIDTH, 6) - VectorSize : (VectorSize * 8 + 2) / 6) : 0;
+                                            (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ? cf_math_pkg::ceil_div(LaneWidth, 6) - VectorSize : cf_math_pkg::ceil_div(LaneWidth, 6)) : 0;
   localparam int unsigned FP4_VECTOR_SIZE = (FpSrcFmtConfig[fpnew_pkg::FP4] == 1) ?
                                             (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ?
                                             (((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ? (VectorSize - FP6_VECTOR_SIZE) : VectorSize) : 2*VectorSize) : 0;

--- a/src/fpnew_mxdotp_multi.sv
+++ b/src/fpnew_mxdotp_multi.sv
@@ -105,7 +105,7 @@ module fpnew_mxdotp_multi
   // -----------------------------------------
   // Computed from module parameters instead of package constants
   localparam int unsigned FP6_VECTOR_SIZE = ((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ?
-                                            (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ? cc_pkg::ceil_div(VectorSize * SRC_WIDTH, 6) - VectorSize : (VectorSize * 8 + 2) / 6) : 0;
+                                            (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ? cf_math_pkg::ceil_div(VectorSize * SRC_WIDTH, 6) - VectorSize : (VectorSize * 8 + 2) / 6) : 0;
   localparam int unsigned FP4_VECTOR_SIZE = (FpSrcFmtConfig[fpnew_pkg::FP4] == 1) ?
                                             (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ?
                                             (((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ? (VectorSize - FP6_VECTOR_SIZE) : VectorSize) : 2*VectorSize) : 0;

--- a/src/fpnew_mxdotp_multi.sv
+++ b/src/fpnew_mxdotp_multi.sv
@@ -22,10 +22,13 @@ module fpnew_mxdotp_multi
   parameter fpnew_pkg::fmt_logic_t   FpSrcFmtConfig  = MxdotpSrcFpFmtConfig,
   parameter fpnew_pkg::ifmt_logic_t  IntSrcFmtConfig = MxdotpSrcIntFmtConfig,
   parameter fpnew_pkg::fmt_logic_t   FpDstFmtConfig  = MxdotpDstFpFmtConfig,
+  parameter int unsigned             VectorSize  = 8,
   parameter int unsigned             NumPipeRegs = 4,
   parameter fpnew_pkg::pipe_config_t PipeConfig  = fpnew_pkg::BEFORE,
   parameter type                     TagType     = logic,
-  parameter type                     AuxType     = logic
+  parameter type                     AuxType     = logic,
+  // Do not change the following parameters
+  localparam int unsigned            NUM_OPERANDS = 2*VectorSize+1
 ) (
   input  logic                        clk_i,
   input  logic                        rst_ni,
@@ -102,10 +105,10 @@ module fpnew_mxdotp_multi
   // -----------------------------------------
   // Computed from module parameters instead of package constants
   localparam int unsigned FP6_VECTOR_SIZE = ((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ?
-                                            (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ? 3 : 11) : 0;
+                                            (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ? cc_pkg::ceil_div(VectorSize * SRC_WIDTH, 6) - VectorSize : (VectorSize * 8 + 2) / 6) : 0;
   localparam int unsigned FP4_VECTOR_SIZE = (FpSrcFmtConfig[fpnew_pkg::FP4] == 1) ?
                                             (((FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) == 1) ?
-                                            (((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ? 5 : 8) : 16) : 0;
+                                            (((FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) == 1) ? (VectorSize - FP6_VECTOR_SIZE) : VectorSize) : 2*VectorSize) : 0;
 
   localparam int unsigned INT_SUPER_BITS = fpnew_pkg::max_int_width(IntSrcFmtConfig);
 
@@ -114,6 +117,13 @@ module fpnew_mxdotp_multi
 
   localparam int unsigned FP6_SUM_WIDTH = $clog2(FP6_VECTOR_SIZE) + FP6_PROD_SHIFT_WIDTH;
   localparam int unsigned FP4_SUM_WIDTH = $clog2(FP4_VECTOR_SIZE) + FP4_PROD_SHIFT_WIDTH;
+
+  // Accumulator Constants
+  localparam int unsigned VECTOR_BITS          = $clog2(VectorSize);
+  localparam int unsigned SOP_FIXED_WIDTH      = VECTOR_BITS + PROD_SHIFT_WIDTH;
+  localparam int unsigned FIXED_SUM_WIDTH      = 1 + DST_PRECISION_BITS + 1 + (SOP_FIXED_WIDTH - 1); // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH        = FIXED_SUM_WIDTH + DST_PRECISION_BITS;
+  localparam int unsigned LZC_RESULT_WIDTH     = $clog2(LZC_SUM_WIDTH);
 
   // ---------------
   // Input pipeline
@@ -276,11 +286,12 @@ module fpnew_mxdotp_multi
   fpnew_pkg::fp_info_t [FP4_VECTOR_SIZE-1:0] fp4_info_a, fp4_info_b;
 
   fpnew_mxdotp_classifier #(
-    .FpSrcFmtConfig ( FpSrcFmtConfig ),
-    .FpDstFmtConfig ( FpDstFmtConfig ),
+    .FpSrcFmtConfig ( FpSrcFmtConfig  ),
+    .FpDstFmtConfig ( FpDstFmtConfig  ),
+    .VectorSize     ( VectorSize      ),
     .FP6VectorSize  ( FP6_VECTOR_SIZE ),
     .FP4VectorSize  ( FP4_VECTOR_SIZE ),
-    .NumInpRegs     ( NUM_INP_REGS )
+    .NumInpRegs     ( NUM_INP_REGS    )
   ) i_classifier (
     .operands_post_inp_pipe(operands_post_inp_pipe),
     .fp6_operands_post_inp_pipe(fp6_operands_post_inp_pipe),
@@ -320,7 +331,8 @@ module fpnew_mxdotp_multi
   // Inf and NaN do not exists in FP6 and FP4 formats
   if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) begin : special_case_handling
     fpnew_mxdotp_special_cases #(
-      .FpDstFmtConfig ( FpDstFmtConfig )
+      .FpDstFmtConfig ( FpDstFmtConfig ),
+      .VectorSize     ( VectorSize     )
     ) i_special_cases (
       .operands_a(operands_a),
       .operands_b(operands_b),
@@ -623,6 +635,7 @@ module fpnew_mxdotp_multi
 
   // Unified format adder: handles FP8 + FP6 + FP4 (FP6/FP4 are zero when disabled)
   fpnew_mxdotp_format_adder #(
+    .SoPFixedWidth ( SOP_FIXED_WIDTH ),
     .Fp6SumWidth ( FP6_SUM_WIDTH ),
     .Fp4SumWidth ( FP4_SUM_WIDTH )
   ) i_format_adder (
@@ -722,6 +735,7 @@ module fpnew_mxdotp_multi
   logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining;
 
   fpnew_mxdotp_accumulator_shift #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_accumulator_shift (
     .sum_product(sum_product_q),
     .scale(scale_q),
@@ -743,6 +757,7 @@ module fpnew_mxdotp_multi
   logic signed [LZC_SUM_WIDTH-1:0] sum_product_accumulator_extended;
 
   fpnew_mxdotp_add_accumulator_sop #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_add_accumulator_sop (
     .sum_product(sum_product_q),
     .accumulator_shifted(accumulator_shifted),
@@ -757,6 +772,7 @@ module fpnew_mxdotp_multi
   logic [LZC_SUM_WIDTH-1:0] sum_magnitude;
 
   fpnew_mxdotp_twos_compl #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_twos_compl (
     .sum_product_accumulator_extended ( sum_product_accumulator_extended ),
     .signed_mantissa_d                ( signed_mantissa_d                ),
@@ -854,6 +870,7 @@ module fpnew_mxdotp_multi
   logic                             lzc_zeroes;
 
   fpnew_mxdotp_norm_lzc #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_norm_lzc (
     .sum_magnitude         ( sum_magnitude_q        ),
     .leading_zero_count_sgn( leading_zero_count_sgn ),
@@ -978,6 +995,7 @@ module fpnew_mxdotp_multi
   logic                            sticky_after_norm;
 
   fpnew_mxdotp_norm_finalize #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_norm_finalize (
     .sum_magnitude          ( sum_magnitude_q2         ),
     .leading_zero_count_sgn ( leading_zero_count_sgn_q ),
@@ -999,7 +1017,8 @@ module fpnew_mxdotp_multi
   logic uf_after_round; // underflow
 
   fpnew_mxdotp_rounder #(
-    .FpDstFmtConfig ( FpDstFmtConfig )
+    .FpDstFmtConfig ( FpDstFmtConfig ),
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_rounder (
     .clk_i(clk_i),
     .rst_ni(rst_ni),

--- a/src/fpnew_mxdotp_multi_wrapper.sv
+++ b/src/fpnew_mxdotp_multi_wrapper.sv
@@ -17,6 +17,7 @@ module fpnew_mxdotp_multi_wrapper
   import fpnew_mxdotp_multi_pkg::*;
 #(
   parameter int unsigned             LaneWidth       = 64,
+  parameter int unsigned             VectorSize      = 8,
   parameter fpnew_pkg::fmt_logic_t   FpSrcFmtConfig  = '1,  // Supported FP source formats (FP8, FP8ALT, FP6, FP6ALT, FP4)
   parameter fpnew_pkg::ifmt_logic_t  IntSrcFmtConfig = '1,  // Supported INT formats (INT8)
   parameter fpnew_pkg::fmt_logic_t   FpDstFmtConfig  = '1,  // Supported FP destination formats (FP32, FP16ALT)
@@ -28,7 +29,8 @@ module fpnew_mxdotp_multi_wrapper
   parameter fpnew_pkg::rsr_impl_t    StochasticRndImplementation = fpnew_pkg::DEFAULT_NO_RSR,
   // Do not change
   localparam int                     OPERAND_WIDTH    = LaneWidth,
-  localparam int                     UNROLL_IDX_WIDTH = (Unroll > 1) ? $clog2(Unroll) : 1
+  localparam int                     UNROLL_IDX_WIDTH = (Unroll > 1) ? $clog2(Unroll) : 1,
+  localparam int unsigned            NUM_OPERANDS     = 2*VectorSize+1
 ) (
   input logic                          clk_i,
   input logic                          rst_ni,
@@ -200,6 +202,7 @@ module fpnew_mxdotp_multi_wrapper
     .FpSrcFmtConfig     ( FpSrcFmtConfig  ),
     .IntSrcFmtConfig    ( IntSrcFmtConfig ),
     .FpDstFmtConfig     ( FpDstFmtConfig  ),
+    .VectorSize         ( VectorSize      ),
     .NumPipeRegs        ( NumPipeRegs     ),
     .PipeConfig         ( PipeConfig      ),
     .TagType            ( TagType         ),

--- a/src/fpnew_mxdotp_multi_wrapper.sv
+++ b/src/fpnew_mxdotp_multi_wrapper.sv
@@ -202,6 +202,7 @@ module fpnew_mxdotp_multi_wrapper
     .FpSrcFmtConfig     ( FpSrcFmtConfig  ),
     .IntSrcFmtConfig    ( IntSrcFmtConfig ),
     .FpDstFmtConfig     ( FpDstFmtConfig  ),
+    .LaneWidth          ( LaneWidth       ),
     .VectorSize         ( VectorSize      ),
     .NumPipeRegs        ( NumPipeRegs     ),
     .PipeConfig         ( PipeConfig      ),

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -556,6 +556,7 @@ or on 16b inputs producing 32b outputs");
         );
       end else if (OpGroup == fpnew_pkg::MXDOTP) begin : lane_instance
         fpnew_mxdotp_multi_wrapper #(
+          .LaneWidth       ( LANE_WIDTH           ),
           .FpSrcFmtConfig  ( MXDOTP_FP_FORMATS    ),
           .IntSrcFmtConfig ( MXDOTP_INT_FORMATS   ),
           .FpDstFmtConfig  ( MXDOTP_DST_FORMATS   ),

--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -20,9 +20,12 @@ module fpnew_mxdotp_classifier
 #(
   parameter fpnew_pkg::fmt_logic_t FpSrcFmtConfig = MxdotpSrcFpFmtConfig,
   parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig,
+  parameter int unsigned           VectorSize     = 8,
   parameter int unsigned           FP6VectorSize  = 3,
   parameter int unsigned           FP4VectorSize  = 5,
-  parameter int unsigned           NumInpRegs     = 0
+  parameter int unsigned           NumInpRegs     = 0,
+  // Do not change the following parameters
+  localparam int unsigned          NUM_OPERANDS   = 2*VectorSize+1
 ) (
   // Input signals
   input logic [2*VectorSize-1:0][SRC_WIDTH-1:0] operands_post_inp_pipe,
@@ -293,7 +296,8 @@ endmodule
 module fpnew_mxdotp_special_cases
   import fpnew_mxdotp_multi_pkg::*;
 #(
-  parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig
+  parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig,
+  parameter int unsigned           VectorSize     = 8
 ) (
   // Input signals
   input  fp_src_t [VectorSize-1:0]             operands_a,
@@ -613,10 +617,13 @@ endmodule
 module fpnew_mxdotp_format_adder
   import fpnew_mxdotp_multi_pkg::*;
 #(
+  parameter int unsigned SoPFixedWidth = 70,
   parameter int unsigned Fp6SumWidth = FP6_PROD_SHIFT_WIDTH,
-  parameter int unsigned Fp4SumWidth = FP4_PROD_SHIFT_WIDTH
+  parameter int unsigned Fp4SumWidth = FP4_PROD_SHIFT_WIDTH,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1) // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
 ) (
-  input  logic signed [SOP_FIXED_WIDTH-1:0] sum_product_fp8,
+  input  logic signed [SoPFixedWidth-1:0] sum_product_fp8,
   input  logic signed [Fp6SumWidth-1:0]     sum_product_fp6,
   input  logic signed [Fp4SumWidth-1:0]     sum_product_fp4,
   output logic signed [FIXED_SUM_WIDTH-1:0] sum_product
@@ -636,7 +643,12 @@ endmodule
 // Computes shift amount, handles sticky bits, and detects if accumulator dominates the result.
 module fpnew_mxdotp_accumulator_shift
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int signed MAX_ACC_SHIFT_AMOUNT = FIXED_SUM_WIDTH - DST_PRECISION_BITS - 1
+) (
   // Input signals
   input  logic signed [FIXED_SUM_WIDTH-1:0] sum_product,
   input  logic [SCALE_WIDTH:0] scale,
@@ -700,7 +712,12 @@ endmodule
 // Adds aligned accumulator to sum-of-products, extending with accumulator remainder bits.
 module fpnew_mxdotp_add_accumulator_sop
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS
+) (
   // Input signals
   input  logic signed [FIXED_SUM_WIDTH-1:0] sum_product,
   input  logic signed [FIXED_SUM_WIDTH-1:0] accumulator_shifted,
@@ -717,7 +734,12 @@ endmodule
 // Converts results to sign-magnitude format using two's complement.
 module fpnew_mxdotp_twos_compl
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS
+) (
   // Input signals
   input  logic [LZC_SUM_WIDTH-1:0] sum_product_accumulator_extended,
   input  logic signed [DST_PRECISION_BITS :0] signed_mantissa_d,
@@ -746,7 +768,14 @@ endmodule
 // Shifts magnitude left by normalization amount to align leading 1 to implicit bit position.
 module fpnew_mxdotp_norm_shift
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS,
+  // Shift amount width: $clog2(DST_BIAS - ANCHOR + (scale_a+scale_b) + FIXED_SUM_WIDTH - 1)
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(fpnew_pkg::bias(fpnew_pkg::FP32) - ANCHOR + 2**(SCALE_WIDTH) - 1 + FIXED_SUM_WIDTH - 1)
+) (
   // Input signals
   input  logic [LZC_SUM_WIDTH-1:0] sum_magnitude,
   input  logic [SHIFT_AMOUNT_WIDTH-1:0] norm_shamt,
@@ -765,7 +794,13 @@ endmodule
 // count. Handles subnormals (normalized_exponent = 0) and zero (lzc_zeroes path).
 module fpnew_mxdotp_norm_lzc
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS,
+  localparam int unsigned LZC_RESULT_WIDTH = $clog2(LZC_SUM_WIDTH)
+) (
   input  logic [LZC_SUM_WIDTH-1:0] sum_magnitude,
   output logic signed [LZC_RESULT_WIDTH:0] leading_zero_count_sgn,
   output logic lzc_zeroes
@@ -789,7 +824,15 @@ endmodule
 // accumulator_sticky is OR'd into sticky_after_norm.
 module fpnew_mxdotp_norm_finalize
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS,
+  localparam int unsigned LZC_RESULT_WIDTH = $clog2(LZC_SUM_WIDTH),
+  // Shift amount width: $clog2(DST_BIAS - ANCHOR + (scale_a+scale_b) + FIXED_SUM_WIDTH - 1)
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(fpnew_pkg::bias(fpnew_pkg::FP32) - ANCHOR + 2**(SCALE_WIDTH) - 1 + FIXED_SUM_WIDTH - 1)
+) (
   input  logic [LZC_SUM_WIDTH-1:0]          sum_magnitude,
   input  logic signed [LZC_RESULT_WIDTH:0]  leading_zero_count_sgn,
   input  logic                              lzc_zeroes,
@@ -824,6 +867,7 @@ module fpnew_mxdotp_norm_finalize
   end
 
   fpnew_mxdotp_norm_shift #(
+    .SoPFixedWidth  ( SoPFixedWidth )
   ) i_norm_shift (
     .sum_shifted  ( sum_shifted  ),
     .sum_magnitude( sum_magnitude),
@@ -841,7 +885,11 @@ endmodule
 module fpnew_mxdotp_rounder
   import fpnew_mxdotp_multi_pkg::*;
 #(
-  parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig
+  parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig,
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS
 ) (
   // Input signals
   input  logic clk_i,

--- a/src/mxdotp/fpnew_mxdotp_multi_pkg.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_pkg.sv
@@ -22,13 +22,11 @@ package fpnew_mxdotp_multi_pkg;
   localparam fpnew_pkg::fmt_logic_t   MxdotpSrcFpFmtConfig  = 9'b000101111; // FP8, FP8ALT, FP6, FP6ALT, FP4
   localparam fpnew_pkg::ifmt_logic_t  MxdotpSrcIntFmtConfig = 4'b1000;      // INT8
   localparam fpnew_pkg::fmt_logic_t   MxdotpDstFpFmtConfig  = 9'b100010000; // FP32, FP16ALT
-  localparam int unsigned             VectorSize            = 8;
 
   // Do not change
   localparam int unsigned SRC_WIDTH    = fpnew_pkg::max_fp_width(MxdotpSrcFpFmtConfig);
   localparam int unsigned DST_WIDTH    = fpnew_pkg::max_fp_width(MxdotpDstFpFmtConfig);
   localparam int unsigned SCALE_WIDTH  = 8;
-  localparam int unsigned NUM_OPERANDS = 2*VectorSize+1; // Two input vectors + accumulator (scale handled separately)
   localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS;
   // ----------
   // Constants
@@ -61,13 +59,7 @@ package fpnew_mxdotp_multi_pkg;
   // Algorithm constants
   localparam int unsigned ANCHOR               = 34; // Fractional point position
   localparam int unsigned INT_BITS             = 32;
-  localparam int unsigned VECTOR_BITS          = $clog2(VectorSize);
   localparam int unsigned PROD_SHIFT_WIDTH     = 1 + INT_BITS + ANCHOR;
-  localparam int unsigned SOP_FIXED_WIDTH      = VECTOR_BITS + PROD_SHIFT_WIDTH;
-  localparam int unsigned FIXED_SUM_WIDTH      = 1 + DST_PRECISION_BITS + 1 + (SOP_FIXED_WIDTH - 1); // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
-  localparam int unsigned LZC_SUM_WIDTH        = FIXED_SUM_WIDTH + DST_PRECISION_BITS;
-  localparam int unsigned LZC_RESULT_WIDTH     = $clog2(LZC_SUM_WIDTH);
-  localparam int signed   MAX_ACC_SHIFT_AMOUNT = FIXED_SUM_WIDTH - DST_PRECISION_BITS - 1; // Maximum allowable shift, -1 for the sign bit
   localparam int unsigned SOP_SHIFT            = ANCHOR - 2*SUPER_MAN_BITS; // Constant left shift amount for the SOP to align the fractional point
 
   // FP6 specific
@@ -83,8 +75,6 @@ package fpnew_mxdotp_multi_pkg;
   // In most reasonable FP formats the internal exponent will be wider than the LZC result.
   localparam int unsigned EXP_WIDTH          = SUPER_EXP_BITS + 1;
   localparam int unsigned DST_EXP_WIDTH      = SUPER_DST_EXP_BITS + 2; // +2 for overflow handling
-  // Shift amount width: $clog2(DST_BIAS - ANCHOR + (scale_a+scale_b) + FIXED_SUM_WIDTH - 1)
-  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(fpnew_pkg::bias(fpnew_pkg::FP32) - ANCHOR + 2**(SCALE_WIDTH) - 1 + FIXED_SUM_WIDTH - 1);
 
   // ----------------
   // Type definition


### PR DESCRIPTION
VectorSize is now a module parameter in MXDOTP

Parameterization for FP4_VECTOR_SIZE and FP6_VECTOR_SIZE based on VectorSize

TODO: Bump to common_cells v2.0.0-beta.2