### PR TITLE
Collapse the INT8/FP8 alignment select into an OR in the FP8 product shifter

### DIFF
--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -564,19 +564,51 @@ module fpnew_mxdotp_product_shifter
     assign exponent_product[i] = operands_a[i].exponent + info_a[i].is_subnormal
                                 + operands_b[i].exponent + info_b[i].is_subnormal
                                 - 2*signed'(bias_constant(src_fmt));
-    if (SrcFmt == fpnew_pkg::FP8) begin
-      always_comb begin // TODO: Generate only for INT8 vs FP8
-        if (src_is_int && int_fmt == fpnew_pkg::INT8) begin
-          // INT8: shift to integer position
-          shifted_product[i] = signed'(product_signed[i]) << ANCHOR;
-        end else begin
-          // Right shift the significand by anchor point - exponent
-          // sum of four 9-bit numbers can be at most 11 bits, for 69 bits output we need to shift by 69 - 11 = 58
-          // 58-30=28 plus inherit 6 fractional bits from the multiplication -> point moves to 28+6=34
-          // max shift can be 58 (28 + exp-max(30)), min shift is 0 (28 + exp-min(-28))
-          shifted_product[i] = signed'(product_signed[i]) << (signed'(SOP_SHIFT) + signed'(exponent_product[i]));
-        end
-      end
+    if (SrcFmt == fpnew_pkg::FP8) begin : gen_align_fp8
+      // The INT8 and FP8 arms of the original 2:1 select are made DISJOINT, so
+      // the select degenerates into an OR and disappears from the low ANCHOR
+      // bits entirely.
+      //
+      //  * the INT8 arm, `product << ANCHOR`, is zero below bit ANCHOR by
+      //    construction;
+      //  * the FP8 arm is forced to zero over the WHOLE word when INT8 is
+      //    selected, by OR-ing the shift amount to all ones.  `shift_amount` is
+      //    AmtWidth = ExpWidth+1 = 7 bits, so all ones is 127 >= OutputWidth
+      //    and the variable shifter returns zero.
+      //
+      // Narrowing the shift amount to AmtWidth is itself exact: exponent_product
+      // is ExpWidth-bit signed, so SOP_SHIFT + exponent_product lies in
+      // [SOP_SHIFT-2**(ExpWidth-1), SOP_SHIFT+2**(ExpWidth-1)-1] = [-4, 59].
+      // Non-negative values are <= 59 < OutputWidth and pass through unchanged;
+      // negative ones wrap to [124, 127], all >= OutputWidth, and so still
+      // produce the all-zero result the original 32-bit signed expression gave.
+      // No reachable value lands in [OutputWidth, 2**AmtWidth) by accident.
+      localparam int unsigned AmtWidth = ExpWidth + 1;
+      localparam int unsigned HiBits   = OutputWidth - ANCHOR;
+
+      logic                          is_int8;
+      logic [AmtWidth-1:0]           shift_amount;
+      logic signed [OutputWidth-1:0] barrel;
+      logic [ProductBits-1:0]        product_gated;
+      logic signed [HiBits-1:0]      int8_hi;
+
+      assign is_int8 = src_is_int && (int_fmt == fpnew_pkg::INT8);
+
+      // Right shift the significand by anchor point - exponent
+      // sum of four 9-bit numbers can be at most 11 bits, for 69 bits output we need to shift by 69 - 11 = 58
+      // 58-30=28 plus inherit 6 fractional bits from the multiplication -> point moves to 28+6=34
+      // max shift can be 58 (28 + exp-max(30)), min shift is 0 (28 + exp-min(-28))
+      assign shift_amount = AmtWidth'(signed'(SOP_SHIFT) + signed'(exponent_product[i]))
+                            | {AmtWidth{is_int8}};
+      assign barrel       = signed'(product_signed[i]) << shift_amount;
+
+      // INT8: shift to integer position.  Gating the ProductBits-wide product
+      // rather than the OutputWidth-wide shifted word is what makes the merge
+      // cheap: OutputWidth-ANCHOR bits of OR instead of a full-width select.
+      assign product_gated = product_signed[i] & {ProductBits{is_int8}};
+      assign int8_hi       = signed'(product_gated);
+
+      assign shifted_product[i] = barrel | {int8_hi, {ANCHOR{1'b0}}};
     end else if (SrcFmt == fpnew_pkg::FP6) begin
       // E3 exponent_product is in range [-4, 8], requires 5b for signed representation
       // To make shift positive, we scale by 4


### PR DESCRIPTION
### What

`fpnew_mxdotp_product_shifter`'s FP8 instance selects between the INT8 and FP8
alignment arms with a 2:1 mux that is `OutputWidth` (67) bits wide on each of
the 8 lanes:

```systemverilog
if (src_is_int && int_fmt == fpnew_pkg::INT8)
  shifted_product[i] = signed'(product_signed[i]) << ANCHOR;
else
  shifted_product[i] = signed'(product_signed[i]) << (signed'(SOP_SHIFT) + signed'(exponent_product[i]));
```

On the low `ANCHOR` = 34 bits that mux does no work. The INT8 arm is identically
zero there, so those bits reduce to `~is_int8 & barrel[k]` — 272 AND gates per
lane-set whose only job is to reproduce a zero the other arm already has.

This PR makes the two arms **disjoint**, so the select degenerates into an OR and
disappears from those bits entirely. The FP8 arm is forced to zero over the whole
word when INT8 is selected, by OR-ing the alignment shift amount to all ones —
`AmtWidth = ExpWidth+1 = 7` bits, so all ones is 127 ≥ `OutputWidth` and the
variable shifter returns zero. The INT8 gating then lands on the
`ProductBits`-wide product instead of the `OutputWidth`-wide shifted word.

### Why the narrowing is exact

Introducing an explicit `AmtWidth`-wide shift amount is exact for **every** input,
not just reachable ones. `exponent_product` is `ExpWidth`-bit signed, so
`SOP_SHIFT + exponent_product` lies in `[-4, 59]`:

* non-negative values are ≤ 59 < `OutputWidth`, and pass through unchanged;
* negative values wrap to `[124, 127]`, all ≥ `OutputWidth`, so they still yield
  the all-zero result the original 32-bit signed expression gave.

Nothing lands in `[OutputWidth, 2**AmtWidth)`, so there is no gap to argue about.

### Verification

Equivalence is proved compositionally rather than by one flat run on the whole
unit, which lets it quantify over **all** port values (including combinations the
surrounding logic cannot produce) and over **every** `VectorSize`, not just the
default.

**Lemma C — the change is confined to one module.** One file, 45+/13-; the
enclosing module of every changed line is `fpnew_mxdotp_product_shifter`, which
spans lines 536-621. The FP6/FP4 branches and the `exponent_product` computation
are byte-identical to `eb505fe`.

**Lemma P — the harness binds the real parameters.** `fpnew_mxdotp_multi`
instantiates the shifter three times, exactly once with `SrcFmt(FP8)`. Extracting
that instance's parameter map and the harness's and diffing them mechanically
gives an exact match:

| real instantiation | proof harness |
|---|---|
| `SrcType(fp_src_t)` | `SrcType(fp_src_t)` |
| `SrcFmt(fpnew_pkg::FP8)` | `SrcFmt(fpnew_pkg::FP8)` |
| `ExpWidth(EXP_WIDTH)` | `ExpWidth(EXP_WIDTH)` |
| `OutputWidth(PROD_SHIFT_WIDTH)` | `OutputWidth(PROD_SHIFT_WIDTH)` |
| `ProductBits(PROD_BITS)` | `ProductBits(PROD_BITS_L)` — same expression |
| `LocalVectorSize(VectorSize)` | `LocalVectorSize(VS)` — swept below |

`PROD_BITS_L` repeats `PROD_BITS`'s definition verbatim
(`maximum(2*INT_SUPER_BITS, 2*PRECISION_BITS+1)`), with `IntSrcFmtConfig` fixed
to its default `MxdotpSrcIntFmtConfig` = `4'b1000` — the only integer
configuration MXDOTP supports, and the only one under which the INT8 arm exists.
Every parameter except `LocalVectorSize` is `VectorSize`-independent.

**Lemma I — lane independence.** Inside the FP8 branch the only array index that
appears is the genvar `i`; the sole non-indexed references are the broadcast
scalars `src_is_int` and `int_fmt`. Lanes therefore cannot interact, so
equivalence at one lane count implies it at all of them. Confirmed empirically:
the AIG node saving is *exactly* 409 per lane at N = 1, 2, 8 and 32.

**Lemma L(N) — module equivalence**, yosys + abc `cec -n`, 0 latches throughout:

| `VectorSize` | PI | PO | gold AIG | cand AIG | result | time |
|---|---|---|---|---|---|---|
| 1  | 55   | 67   | 1569  | 1160  | **equivalent** | 0.04 s |
| 2  | 103  | 134  | 2966  | 2148  | **equivalent** | 0.20 s |
| 8  | 391  | 536  | 11348 | 8076  | **equivalent** | 0.51 s |
| 32 | 1543 | 2144 | 44876 | 31788 | **equivalent** | 2.74 s |

PI and PO both scale exactly linearly (48 PI/lane + 7 shared; 67 PO/lane =
`PROD_SHIFT_WIDTH`), which confirms the parameter override actually took effect
rather than silently falling back to a default.

C ∧ P ∧ I ∧ L ⇒ the two designs are equivalent at the `fpnew_mxdotp_multi`
boundary for every `VectorSize`.

**Corroboration without the harness.** The lemma chain routes through a proof
harness, so as an independent check the *whole* `fpnew_mxdotp_multi` was compared
flat, with no harness at all, at `VectorSize=2` / `LaneWidth=16` /
`NumPipeRegs=0` (156 PI / 0 latches / 44 PO): **Networks are equivalent**
(abc `cec -n`, 640 s). This exercises the real instantiation directly, so
together with Lemma I it independently confirms what C ∧ P ∧ I ∧ L give.

The same flat comparison at `VectorSize=8` does not terminate in reasonable time
(`cec -n` exceeded 40 min; `&cec -n` returns 35 of 44 outputs undecided) — which
is why the proof is structured compositionally rather than as one flat run.

**Non-vacuity.** Four mutants, checked against the same golden:

| mutant | expected | result |
|---|---|---|
| forcing term removed | not equivalent | ✓ not equivalent |
| forced to 60 (**<** `OutputWidth`) | not equivalent | ✓ not equivalent |
| INT8 product gating removed | not equivalent | ✓ not equivalent |
| forced to 67 (**=** `OutputWidth`) | equivalent | ✓ equivalent |

The last two bracket the threshold exactly: 60 breaks it, 67 does not. So the
proof turns on `shift_amount >= OutputWidth` and not on the particular all-ones
value, which is what the argument above claims.

Elaborates clean under `slang` (0 errors, 0 warnings) against
`common_cells v2.0.0-beta.2`, the version this branch depends on.

### Simulation

Formal equivalence covers the synthesized cones; it says nothing about
simulation behaviour. A differential testbench (QuestaSim) instantiates the
upstream and patched shifters side by side under identical stimulus:

* 400 064 vectors — directed sweep over every `src_is_int` x `int_fmt` x
  `src_fmt` combination with exponent/product corner values (all-zero, all-ones,
  min, max), plus 200 k uniform-random and 200 k INT8-weighted vectors
  (225 301 hit the INT8 arm, 174 763 the FP arm).
* **0 mismatches.**

Mutation-tested so the result is not vacuous — the same testbench correctly
fails three broken variants and passes an equivalent one, and it discriminates
by arm exactly as expected:

| mutant | vectors failing | arm implicated |
|---|---|---|
| forcing term removed | 225 297 | INT8 |
| forced to 60 (< `OutputWidth`) | 224 187 | INT8 |
| INT8 gating removed | 174 748 | FP |
| forced to 67 (= `OutputWidth`) | 0 | — (equivalent, as expected) |

**One behavioural difference, deliberate.** The original resolves an unknown
`src_is_int` through `always_comb`'s `if`, which in simulation takes the
else-branch and yields a *definite* result — it silently commits to the FP8 arm.
This version computes both arms, so an X on the control propagates. Measured
over 20 000 vectors with `src_is_int = 1'bx`: the original produced a defined
output every time, this version produces X every time.

This is X-pessimism, not a functional change — for all defined inputs the two
agree on every vector above, and the synthesized netlists are proved equivalent.
It is arguably the safer behaviour, since it surfaces uninitialised control
rather than masking it. But an integration testbench that currently tolerates an
undriven `src_is_int` would begin to see X, so it is worth knowing before
merging.

### Effect

Technology-independent AIG node count (proxy for area):

| cone | before | after | |
|---|---|---|---|
| whole `fpnew_mxdotp_multi` | 52438 | 49130 | **−6.3 %** |
| FP8 shifter alone | 11348 | 8076 | **−28.9 %** |

### Notes

* FP6 and FP4 paths are untouched — they have no INT8 arm.
* No port or parameter changes; the module interface is unchanged.
