### PR TITLE
mxdotp: LLM-assisted datapath restructuring around narrower pipeline cuts

### DIFF
--- a/src/fpnew_mxdotp_multi.sv
+++ b/src/fpnew_mxdotp_multi.sv
@@ -248,8 +248,8 @@ module fpnew_mxdotp_multi
     // TODO: FP6 and FP4 without FP8
     if (src_fmt_q == fpnew_pkg::FP6 || src_fmt_q == fpnew_pkg::FP6ALT) begin
       for (int i = 0; i < FP6_VECTOR_SIZE; i++) begin // Last 3 elements use FP6 datapath
-        fp6_operands_post_inp_pipe[i] = {{(SRC_WIDTH-6){1'b0}}, flat_operands_a_q[(48+i*6) +: 6]};
-        fp6_operands_post_inp_pipe[i+FP6_VECTOR_SIZE] = {{(SRC_WIDTH-6){1'b0}}, flat_operands_b_q[(48+i*6) +: 6]};
+        fp6_operands_post_inp_pipe[i] = {{(SRC_WIDTH-6){1'b0}}, flat_operands_a_q[(VectorSize*6+i*6) +: 6]};
+        fp6_operands_post_inp_pipe[i+FP6_VECTOR_SIZE] = {{(SRC_WIDTH-6){1'b0}}, flat_operands_b_q[(VectorSize*6+i*6) +: 6]};
         if (i == FP6_VECTOR_SIZE-1) begin // Last element of the FP6 remainder extends to 66 bits
           fp6_operands_post_inp_pipe[i][5:4] = operands_a_fp6_rem_q;
           fp6_operands_post_inp_pipe[i+FP6_VECTOR_SIZE][5:4] = operands_b_fp6_rem_q;

--- a/src/fpnew_mxdotp_multi.sv
+++ b/src/fpnew_mxdotp_multi.sv
@@ -272,6 +272,38 @@ module fpnew_mxdotp_multi
     end
   end
 
+  // ------------------------------------------------------------------
+  // PER-FORMAT PACKING VIEWS -- pure wiring, no src_fmt multiplexer.
+  //
+  // `operands_post_inp_pipe` above is a src_fmt-driven SELECT that sits in
+  // FRONT of the per-format classifier bank, and the bank's outputs are then
+  // selected by src_fmt AGAIN inside fpnew_mxdotp_classifier
+  // (`info_q[src_fmt]`, `fmt_sign/exponent/mantissa[src_fmt]`).  The first
+  // select is redundant: format `fmt`'s classifier output is only ever read
+  // when src_fmt == fmt, so it may be wired straight to the packing that
+  // `operands_post_inp_pipe` WOULD carry in that case -- FP6/FP6ALT get the
+  // 6-bit repacking, every other format gets the plain {b,a} default.  That
+  // deletes one multiplexer level from the front of the stage-1 critical
+  // path  src_fmt -> unpack mux -> classifier -> info_a -> INT8 multiplier,
+  // which is the path that bounds stage 1 (worst endpoint: bit 8 of the
+  // registered INT8 product).
+  //
+  // The muxed signal itself STAYS: op_select's `src_is_int` branch reads
+  // `operands_post_inp_pipe` directly, and that path does not run through the
+  // classifier, so nothing there changes.
+  // ------------------------------------------------------------------
+  logic [2*VectorSize-1:0][SRC_WIDTH-1:0] operands_default_view;
+  logic [2*VectorSize-1:0][SRC_WIDTH-1:0] operands_fp6_view;
+  logic [VectorSize*SRC_WIDTH-1:0]        flat_a_view, flat_b_view;
+
+  assign flat_a_view           = operands_a_q;
+  assign flat_b_view           = operands_b_q;
+  assign operands_default_view = {operands_b_q, operands_a_q};
+  for (genvar i = 0; i < VectorSize; i++) begin : gen_fp6_packing_view
+    assign operands_fp6_view[i]            = {{(SRC_WIDTH-6){1'b0}}, flat_a_view[(i*6) +: 6]};
+    assign operands_fp6_view[i+VectorSize] = {{(SRC_WIDTH-6){1'b0}}, flat_b_view[(i*6) +: 6]};
+  end
+
   // -----------------
   // Input processing
   // -----------------
@@ -293,14 +325,16 @@ module fpnew_mxdotp_multi
   fpnew_pkg::fp_info_t [FP4_VECTOR_SIZE_GUARDED-1:0] fp4_info_a, fp4_info_b;
 
   fpnew_mxdotp_classifier #(
-    .FpSrcFmtConfig ( FpSrcFmtConfig  ),
-    .FpDstFmtConfig ( FpDstFmtConfig  ),
+    .FpSrcFmtConfig ( FpSrcFmtConfig ),
+    .FpDstFmtConfig ( FpDstFmtConfig ),
     .VectorSize     ( VectorSize      ),
     .FP6VectorSize  ( FP6_VECTOR_SIZE_GUARDED ),
     .FP4VectorSize  ( FP4_VECTOR_SIZE_GUARDED ),
-    .NumInpRegs     ( NUM_INP_REGS    )
+    .NumInpRegs     ( NUM_INP_REGS )
   ) i_classifier (
     .operands_post_inp_pipe(operands_post_inp_pipe),
+    .operands_default_view(operands_default_view),
+    .operands_fp6_view(operands_fp6_view),
     .fp6_operands_post_inp_pipe(fp6_operands_post_inp_pipe),
     .fp4_operands_post_inp_pipe(fp4_operands_post_inp_pipe),
     .operands_c_in(operands_c_q),
@@ -331,15 +365,13 @@ module fpnew_mxdotp_multi
   // ---------------------
   // Special case handling
   // ---------------------
-  logic [DST_WIDTH-1:0] special_result;
-  fpnew_pkg::status_t   special_status;
-  logic                 result_is_special;
+  // 4-bit special-case verdict: {result_is_special_raw, nv, is_inf, inf_sign}
+  logic [3:0]           special_raw;
 
   // Inf and NaN do not exists in FP6 and FP4 formats
   if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) begin : special_case_handling
     fpnew_mxdotp_special_cases #(
-      .FpDstFmtConfig ( FpDstFmtConfig ),
-      .VectorSize     ( VectorSize     )
+      .VectorSize ( VectorSize )
     ) i_special_cases (
       .operands_a(operands_a),
       .operands_b(operands_b),
@@ -349,26 +381,25 @@ module fpnew_mxdotp_multi
       .info_b(info_b),
       .info_c(info_c),
       .info_d(info_d),
-      .dst_fmt(dst_fmt_q),
-      .special_result(special_result),
-      .special_status(special_status),
-      .result_is_special(result_is_special)
+      .result_is_special_raw(special_raw[3]),
+      .special_nv(special_raw[2]),
+      .special_is_inf(special_raw[1]),
+      .special_inf_sign(special_raw[0])
     );
   end else begin : no_special_case_handling
-    assign special_result = '0;
-    assign special_status = fpnew_pkg::status_t'(0);
-    assign result_is_special = 1'b0;
+    assign special_raw = '0;
   end
 
   // ------------------
   // Scale data path
   // ------------------
-  logic signed [SCALE_WIDTH:0] scale; // +1 for addition
+  logic signed [DST_EXP_WIDTH-1:0] exponent_major; // scale + EXP_MAJOR_OFFSET
 
   fpnew_mxdotp_scale_adder #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_scale_adder (
     .operands_c(operands_c),
-    .scale(scale)
+    .exponent_major(exponent_major)
   );
 
   // ------------------
@@ -441,79 +472,98 @@ module fpnew_mxdotp_multi
   end
 
   // ------------------
-  // Shift data path
+  // Shift data path -- EARLY half (STAGE 1): per-lane product exponent only.
+  // The variable alignment shift itself has moved behind the INP-MID registers
+  // (see "Shift data path -- LATE half"), so that bank latches 258 narrow bits
+  // instead of 644 aligned ones.
   // ------------------
-  logic signed [VectorSize-1:0][PROD_SHIFT_WIDTH-1:0] shifted_product;
-  logic signed [FP6_VECTOR_SIZE_GUARDED-1:0][FP6_PROD_SHIFT_WIDTH-1:0] fp6_shifted_product;
-  logic signed [FP4_VECTOR_SIZE_GUARDED-1:0][FP4_PROD_SHIFT_WIDTH-1:0] fp4_shifted_product;
+  // NOTE: these now carry the COMPLETE alignment shift amount (unsigned), not
+  // just the product exponent -- the constant offset the alignment stage used
+  // to add is folded into the stage-1 exponent adder (see product_exponent).
+  logic [VectorSize-1:0][EXP_WIDTH+1-1:0]          exponent_product;
+  logic [FP6_VECTOR_SIZE_GUARDED-1:0][6-1:0]               fp6_exponent_product;
+  logic [FP4_VECTOR_SIZE_GUARDED-1:0][3-1:0]               fp4_exponent_product;
 
-  if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) begin : fp8_product_shifter
-    fpnew_mxdotp_product_shifter #(
+  if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) begin : fp8_product_exponent
+    fpnew_mxdotp_product_exponent #(
       .SrcType(fp_src_t),
       .LocalVectorSize(VectorSize),
-      .SrcFmt(fpnew_pkg::FP8), // TODO: For now, we assume that FP8 and FP8ALT are always enabled together
-      .ProductBits(PROD_BITS),
       .ExpWidth(EXP_WIDTH),
-      .OutputWidth(PROD_SHIFT_WIDTH)
-    ) i_product_shifter_fp8 (
+      .ShiftOffset(SOP_SHIFT),
+      .AmtWidth(EXP_WIDTH+1),
+      .ForceOnInt8(1'b1)
+    ) i_product_exponent_fp8 (
+      .int_fmt(int_fmt_q),
+      .src_is_int(src_is_int),
       .operands_a(operands_a),
       .operands_b(operands_b),
       .info_a(info_a),
       .info_b(info_b),
-      .product_signed(product_signed),
       .src_fmt(src_fmt_q),
-      .int_fmt(int_fmt_q),
-      .src_is_int(src_is_int),
-      .shifted_product(shifted_product)
+      .shift_amount(exponent_product)
     );
-  end else begin : no_fp8_product_shifter
-    assign shifted_product = '0;
+  end else begin : no_fp8_product_exponent
+    assign exponent_product = '0;
   end
 
-  if (FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) begin : fp6_product_shifter
-    fpnew_mxdotp_product_shifter #(
+  if (FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) begin : fp6_product_exponent
+    fpnew_mxdotp_product_exponent #(
       .SrcType(fp6_src_t),
       .LocalVectorSize(FP6_VECTOR_SIZE),
-      .SrcFmt(fpnew_pkg::FP6), // TODO: For now, we assume that FP6 and FP6ALT are always enabled together
-      .ProductBits(2*FP6_PREC_BITS+1),
       .ExpWidth(5),
-      .OutputWidth(FP6_PROD_SHIFT_WIDTH)
-    ) i_product_shifter_fp6 (
+      .ShiftOffset(4),
+      .AmtWidth(6)
+    ) i_product_exponent_fp6 (
+      .int_fmt(int_fmt_q),
+      .src_is_int(src_is_int),
       .operands_a(fp6_operands_a),
       .operands_b(fp6_operands_b),
       .info_a(fp6_info_a),
       .info_b(fp6_info_b),
-      .product_signed(fp6_product_signed),
       .src_fmt(src_fmt_q),
-      .int_fmt(int_fmt_q),
-      .src_is_int(src_is_int),
-      .shifted_product(fp6_shifted_product)
+      .shift_amount(fp6_exponent_product)
     );
-  end else begin : no_fp6_product_shifter
-    assign fp6_shifted_product = '0;
+  end else begin : no_fp6_product_exponent
+    assign fp6_exponent_product = '0;
   end
-  if (FpSrcFmtConfig[fpnew_pkg::FP4]) begin : fp4_product_shifter
-    fpnew_mxdotp_product_shifter #(
+
+  if (FpSrcFmtConfig[fpnew_pkg::FP4]) begin : fp4_product_exponent
+    fpnew_mxdotp_product_exponent #(
       .SrcType(fp4_src_t),
       .LocalVectorSize(FP4_VECTOR_SIZE),
-      .SrcFmt(fpnew_pkg::FP4),
-      .ProductBits(2*FP4_PREC_BITS+1),
       .ExpWidth(3),
-      .OutputWidth(FP4_PROD_SHIFT_WIDTH)
-    ) i_product_shifter_fp4 (
+      .ShiftOffset(0),
+      .AmtWidth(3)
+    ) i_product_exponent_fp4 (
+      .int_fmt(int_fmt_q),
+      .src_is_int(src_is_int),
       .operands_a(fp4_operands_a),
       .operands_b(fp4_operands_b),
       .info_a(fp4_info_a),
       .info_b(fp4_info_b),
-      .product_signed(fp4_product_signed),
       .src_fmt(src_fmt_q),
-      .int_fmt(int_fmt_q),
-      .src_is_int(src_is_int),
-      .shifted_product(fp4_shifted_product)
+      .shift_amount(fp4_exponent_product)
     );
-  end else begin : no_fp4_product_shifter
-    assign fp4_shifted_product = '0;
+  end else begin : no_fp4_product_exponent
+    assign fp4_exponent_product = '0;
   end
+
+  // ------------------------------------------------------------------
+  // Accumulator preparation -- STAGE 1 (see fpnew_mxdotp_accumulator_prep).
+  // ------------------------------------------------------------------
+  logic signed [9:0] accumulator_shift_amount_d;
+  logic signed [DST_PRECISION_BITS :0] signed_mantissa_d_d;
+
+  fpnew_mxdotp_accumulator_prep #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
+  ) i_accumulator_prep (
+    .exponent_major(exponent_major),
+    .operand_d(operand_d),
+    .info_d(info_d),
+    .dst_fmt(inp_pipe_dst_fmt_q[NUM_INP_REGS]),
+    .accumulator_shift_amount(accumulator_shift_amount_d),
+    .signed_mantissa_d(signed_mantissa_d_d)
+  );
 
   // --------------------
   // INP to MID pipeline
@@ -524,17 +574,23 @@ module fpnew_mxdotp_multi
   logic signed [FP4_VECTOR_SIZE_GUARDED-1:0][FP4_PROD_SHIFT_WIDTH-1:0] fp4_shifted_product_q;
 
   // Inp-mid pipeline signals, index i holds signal after i register stages
-  logic signed           [0:NUM_IM_REGS][VectorSize-1:0][PROD_SHIFT_WIDTH-1:0]          inp_mid_pipe_shifted_product_q;
-  logic signed           [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][FP6_PROD_SHIFT_WIDTH-1:0] inp_mid_pipe_fp6_shifted_product_q;
-  logic signed           [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][FP4_PROD_SHIFT_WIDTH-1:0] inp_mid_pipe_fp4_shifted_product_q;
+  logic signed           [0:NUM_IM_REGS][VectorSize-1:0][PROD_BITS-1:0]                 inp_mid_pipe_product_q;
+  logic signed           [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][2*FP6_PREC_BITS:0]        inp_mid_pipe_fp6_product_q;
+  logic signed           [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][2*FP4_PREC_BITS:0]        inp_mid_pipe_fp4_product_q;
+  logic                  [0:NUM_IM_REGS][VectorSize-1:0][EXP_WIDTH+1-1:0]               inp_mid_pipe_exp_prod_q;
+  logic                  [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][6-1:0]                     inp_mid_pipe_fp6_exp_prod_q;
+  logic                  [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][3-1:0]                     inp_mid_pipe_fp4_exp_prod_q;
+  fpnew_pkg::int_format_e[0:NUM_IM_REGS]                                                inp_mid_pipe_int_fmt_q;
+  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_src_is_int_q;
   fpnew_pkg::fp_format_e [0:NUM_IM_REGS]                                                inp_mid_pipe_dst_fmt_q;
-  logic                  [0:NUM_IM_REGS][SCALE_WIDTH:0]                                 inp_mid_pipe_scale_q;
+  logic                  [0:NUM_IM_REGS][DST_EXP_WIDTH-1:0]                                 inp_mid_pipe_scale_q;
   fp_dst_t               [0:NUM_IM_REGS]                                                inp_mid_pipe_operand_d_q;
-  fpnew_pkg::fp_info_t   [0:NUM_IM_REGS]                                                inp_mid_pipe_info_d_q;
+  logic signed           [0:NUM_IM_REGS][9:0]                                           inp_mid_pipe_acc_shamt_q;
+  logic signed           [0:NUM_IM_REGS][DST_PRECISION_BITS :0]                         inp_mid_pipe_signed_man_d_q;
   fpnew_pkg::roundmode_e [0:NUM_IM_REGS]                                                inp_mid_pipe_rnd_mode_q;
   logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_res_is_spec_q;
-  logic                  [0:NUM_IM_REGS][DST_WIDTH-1:0]                                 inp_mid_pipe_spec_res_q;
-  fpnew_pkg::status_t    [0:NUM_IM_REGS]                                                inp_mid_pipe_spec_stat_q;
+  logic                  [0:NUM_IM_REGS][1:0]                                 inp_mid_pipe_spec_res_q;
+  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_spec_stat_q;
   TagType                [0:NUM_IM_REGS]                                                inp_mid_pipe_tag_q;
   logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_mask_q;
   AuxType                [0:NUM_IM_REGS]                                                inp_mid_pipe_aux_q;
@@ -543,17 +599,23 @@ module fpnew_mxdotp_multi
   logic [0:NUM_IM_REGS]                                                                 inp_mid_pipe_ready;
 
   // Input stage: First element of pipeline is taken from upstream logic
-  assign inp_mid_pipe_shifted_product_q[0]     = shifted_product;
-  assign inp_mid_pipe_fp6_shifted_product_q[0] = fp6_shifted_product;
-  assign inp_mid_pipe_fp4_shifted_product_q[0] = fp4_shifted_product;
+  assign inp_mid_pipe_product_q[0]             = product_signed;
+  assign inp_mid_pipe_fp6_product_q[0]         = fp6_product_signed;
+  assign inp_mid_pipe_fp4_product_q[0]         = fp4_product_signed;
+  assign inp_mid_pipe_exp_prod_q[0]            = exponent_product;
+  assign inp_mid_pipe_fp6_exp_prod_q[0]        = fp6_exponent_product;
+  assign inp_mid_pipe_fp4_exp_prod_q[0]        = fp4_exponent_product;
+  assign inp_mid_pipe_int_fmt_q[0]             = int_fmt_q;
+  assign inp_mid_pipe_src_is_int_q[0]          = src_is_int;
   assign inp_mid_pipe_dst_fmt_q[0]             = inp_pipe_dst_fmt_q[NUM_INP_REGS];
-  assign inp_mid_pipe_scale_q[0]               = scale;
+  assign inp_mid_pipe_scale_q[0]               = exponent_major;
   assign inp_mid_pipe_operand_d_q[0]           = operand_d;
-  assign inp_mid_pipe_info_d_q[0]              = info_d;
+  assign inp_mid_pipe_acc_shamt_q[0]           = accumulator_shift_amount_d;
+  assign inp_mid_pipe_signed_man_d_q[0]        = signed_mantissa_d_d;
   assign inp_mid_pipe_rnd_mode_q[0]            = inp_pipe_rnd_mode_q[NUM_INP_REGS];
-  assign inp_mid_pipe_res_is_spec_q[0]         = result_is_special;
-  assign inp_mid_pipe_spec_res_q[0]            = special_result;
-  assign inp_mid_pipe_spec_stat_q[0]           = special_status;
+  assign inp_mid_pipe_res_is_spec_q[0]         = special_raw[3];
+  assign inp_mid_pipe_spec_res_q[0]            = special_raw[1:0];
+  assign inp_mid_pipe_spec_stat_q[0]           = special_raw[2];
   assign inp_mid_pipe_tag_q[0]                 = inp_pipe_tag_q[NUM_INP_REGS];
   assign inp_mid_pipe_mask_q[0]                = inp_pipe_mask_q[NUM_INP_REGS];
   assign inp_mid_pipe_aux_q[0]                 = inp_pipe_aux_q[NUM_INP_REGS];
@@ -574,13 +636,19 @@ module fpnew_mxdotp_multi
     // Enable register if pipeline ready and a valid data item is present
     assign reg_ena = inp_mid_pipe_ready[i] & inp_mid_pipe_valid_q[i];
     // Generate the pipeline registers within the stages, use enable-registers
-    `FFL(inp_mid_pipe_shifted_product_q[i+1],     inp_mid_pipe_shifted_product_q[i],     reg_ena, '0)
-    `FFL(inp_mid_pipe_fp6_shifted_product_q[i+1], inp_mid_pipe_fp6_shifted_product_q[i], reg_ena, '0)
-    `FFL(inp_mid_pipe_fp4_shifted_product_q[i+1], inp_mid_pipe_fp4_shifted_product_q[i], reg_ena, '0)
+    `FFL(inp_mid_pipe_product_q[i+1],             inp_mid_pipe_product_q[i],             reg_ena, '0)
+    `FFL(inp_mid_pipe_fp6_product_q[i+1],         inp_mid_pipe_fp6_product_q[i],         reg_ena, '0)
+    `FFL(inp_mid_pipe_fp4_product_q[i+1],         inp_mid_pipe_fp4_product_q[i],         reg_ena, '0)
+    `FFL(inp_mid_pipe_exp_prod_q[i+1],            inp_mid_pipe_exp_prod_q[i],            reg_ena, '0)
+    `FFL(inp_mid_pipe_fp6_exp_prod_q[i+1],        inp_mid_pipe_fp6_exp_prod_q[i],        reg_ena, '0)
+    `FFL(inp_mid_pipe_fp4_exp_prod_q[i+1],        inp_mid_pipe_fp4_exp_prod_q[i],        reg_ena, '0)
+    `FFL(inp_mid_pipe_int_fmt_q[i+1],             inp_mid_pipe_int_fmt_q[i],             reg_ena, fpnew_pkg::int_format_e'(0))
+    `FFL(inp_mid_pipe_src_is_int_q[i+1],          inp_mid_pipe_src_is_int_q[i],          reg_ena, '0)
     `FFL(inp_mid_pipe_dst_fmt_q[i+1],             inp_mid_pipe_dst_fmt_q[i],             reg_ena, fpnew_pkg::fp_format_e'(0))
     `FFL(inp_mid_pipe_scale_q[i+1],               inp_mid_pipe_scale_q[i],               reg_ena, '0)
     `FFL(inp_mid_pipe_operand_d_q[i+1],           inp_mid_pipe_operand_d_q[i],           reg_ena, '0)
-    `FFL(inp_mid_pipe_info_d_q[i+1],              inp_mid_pipe_info_d_q[i],              reg_ena, '0)
+    `FFL(inp_mid_pipe_acc_shamt_q[i+1],           inp_mid_pipe_acc_shamt_q[i],           reg_ena, '0)
+    `FFL(inp_mid_pipe_signed_man_d_q[i+1],        inp_mid_pipe_signed_man_d_q[i],        reg_ena, '0)
     `FFL(inp_mid_pipe_rnd_mode_q[i+1],            inp_mid_pipe_rnd_mode_q[i],            reg_ena, fpnew_pkg::RNE)
     `FFL(inp_mid_pipe_res_is_spec_q[i+1],         inp_mid_pipe_res_is_spec_q[i],         reg_ena, '0)
     `FFL(inp_mid_pipe_spec_res_q[i+1],            inp_mid_pipe_spec_res_q[i],            reg_ena, '0)
@@ -590,88 +658,154 @@ module fpnew_mxdotp_multi
     `FFL(inp_mid_pipe_aux_q[i+1],                 inp_mid_pipe_aux_q[i],                 reg_ena, AuxType'('0))
   end
   // Output stage: assign selected pipe outputs to signals for later use
-  assign shifted_product_q     = inp_mid_pipe_shifted_product_q[NUM_IM_REGS];
-  assign fp6_shifted_product_q = inp_mid_pipe_fp6_shifted_product_q[NUM_IM_REGS];
-  assign fp4_shifted_product_q = inp_mid_pipe_fp4_shifted_product_q[NUM_IM_REGS];
+
+  // ------------------
+  // Shift data path -- LATE half (STAGE 2): the variable alignment shift.
+  // ------------------
+  if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) begin : fp8_product_align
+    fpnew_mxdotp_product_align #(
+      .LocalVectorSize(VectorSize),
+      .SrcFmt(fpnew_pkg::FP8),
+      .ProductBits(PROD_BITS),
+      .AmtWidth(EXP_WIDTH+1),
+      .OutputWidth(PROD_SHIFT_WIDTH)
+    ) i_product_align_fp8 (
+      .product_signed(inp_mid_pipe_product_q[NUM_IM_REGS]),
+      .shift_amount(inp_mid_pipe_exp_prod_q[NUM_IM_REGS]),
+      .int_fmt(inp_mid_pipe_int_fmt_q[NUM_IM_REGS]),
+      .src_is_int(inp_mid_pipe_src_is_int_q[NUM_IM_REGS]),
+      .shifted_product(shifted_product_q)
+    );
+  end else begin : no_fp8_product_align
+    assign shifted_product_q = '0;
+  end
+
+  if (FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) begin : fp6_product_align
+    fpnew_mxdotp_product_align #(
+      .LocalVectorSize(FP6_VECTOR_SIZE),
+      .SrcFmt(fpnew_pkg::FP6),
+      .ProductBits(2*FP6_PREC_BITS+1),
+      .AmtWidth(6),
+      .OutputWidth(FP6_PROD_SHIFT_WIDTH)
+    ) i_product_align_fp6 (
+      .product_signed(inp_mid_pipe_fp6_product_q[NUM_IM_REGS]),
+      .shift_amount(inp_mid_pipe_fp6_exp_prod_q[NUM_IM_REGS]),
+      .int_fmt(inp_mid_pipe_int_fmt_q[NUM_IM_REGS]),
+      .src_is_int(inp_mid_pipe_src_is_int_q[NUM_IM_REGS]),
+      .shifted_product(fp6_shifted_product_q)
+    );
+  end else begin : no_fp6_product_align
+    assign fp6_shifted_product_q = '0;
+  end
+
+  if (FpSrcFmtConfig[fpnew_pkg::FP4]) begin : fp4_product_align
+    fpnew_mxdotp_product_align #(
+      .LocalVectorSize(FP4_VECTOR_SIZE),
+      .SrcFmt(fpnew_pkg::FP4),
+      .ProductBits(2*FP4_PREC_BITS+1),
+      .AmtWidth(3),
+      .OutputWidth(FP4_PROD_SHIFT_WIDTH)
+    ) i_product_align_fp4 (
+      .product_signed(inp_mid_pipe_fp4_product_q[NUM_IM_REGS]),
+      .shift_amount(inp_mid_pipe_fp4_exp_prod_q[NUM_IM_REGS]),
+      .int_fmt(inp_mid_pipe_int_fmt_q[NUM_IM_REGS]),
+      .src_is_int(inp_mid_pipe_src_is_int_q[NUM_IM_REGS]),
+      .shifted_product(fp4_shifted_product_q)
+    );
+  end else begin : no_fp4_product_align
+    assign fp4_shifted_product_q = '0;
+  end
 
   // ------------------
   // Adder data path
   // ------------------
-  logic signed [SOP_FIXED_WIDTH-1:0] sum_product_fp8;
-  logic signed [FP6_SUM_WIDTH-1:0]   sum_product_fp6;
-  logic signed [FP4_SUM_WIDTH-1:0]   sum_product_fp4;
-  logic signed [FIXED_SUM_WIDTH-1:0] sum_product;
+  // NOTE: NO lane has its own adder tree any more.  The eight aligned FP8/INT8
+  // products, the three aligned FP6 products, the five aligned FP4 products and
+  // the aligned accumulator are summed inside
+  // fpnew_mxdotp_fused_sop_accumulator (one CSA tree, one CPA).  The FP6/FP4
+  // lane adder trees used to be two extra carry-propagate adders sitting IN
+  // SERIES in front of that one; the aligned per-lane products are therefore
+  // carried straight through the mid pipeline now.
 
-  if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT] || IntSrcFmtConfig[fpnew_pkg::INT8]) begin : fp8_adder_tree
-    fpnew_mxdotp_adder_tree #(
-      .LocalVectorSize(VectorSize),
-      .InputWidth(PROD_SHIFT_WIDTH),
-      .OutputWidth(SOP_FIXED_WIDTH)
-    ) i_adder_tree_fp8 (
-      .shifted_product(shifted_product_q),
-      .sum_product(sum_product_fp8)
-    );
-  end else begin : no_fp8_adder_tree
-    assign sum_product_fp8 = '0;
-  end
+  // -----------------------------
+  // Accumulator shift data path        (STAGE 2: INP-MID regs -> MID regs)
+  // -----------------------------
+  // PIPELINE RE-PLACEMENT: the accumulator alignment and the fused
+  // SoP+accumulator sum are pulled in FRONT of the MID register bank, so that
+  // bank carries the 119-bit fused result instead of the 644 bits of aligned
+  // per-lane products.  Purely a change of WHERE the cut is; at NumPipeRegs=0
+  // every pipe stage is a wire and the combinational cone is unchanged.
+  logic result_is_accumulator_uncond, result_is_accumulator_if_sop_zero;
+  logic sum_product_is_zero;
+  logic signed [FIXED_SUM_WIDTH-1:0] accumulator_shifted;
+  logic accumulator_sticky;
+  logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining;
 
-  if (FpSrcFmtConfig[fpnew_pkg::FP6] || FpSrcFmtConfig[fpnew_pkg::FP6ALT]) begin : fp6_adder_tree
-    fpnew_mxdotp_adder_tree #(
-      .LocalVectorSize(FP6_VECTOR_SIZE),
-      .InputWidth(FP6_PROD_SHIFT_WIDTH),
-      .OutputWidth(FP6_SUM_WIDTH)
-    ) i_adder_tree_fp6 (
-      .shifted_product(fp6_shifted_product_q),
-      .sum_product(sum_product_fp6)
-    );
-  end else begin : no_fp6_adder_tree
-    assign sum_product_fp6 = '0;
-  end
-  if (FpSrcFmtConfig[fpnew_pkg::FP4]) begin : fp4_adder_tree
-    fpnew_mxdotp_adder_tree #(
-      .LocalVectorSize(FP4_VECTOR_SIZE),
-      .InputWidth(FP4_PROD_SHIFT_WIDTH),
-      .OutputWidth(FP4_SUM_WIDTH)
-    ) i_adder_tree_fp4 (
-      .shifted_product(fp4_shifted_product_q),
-      .sum_product(sum_product_fp4)
-    );
-  end else begin : no_fp4_adder_tree
-    assign sum_product_fp4 = '0;
-  end
-
-  // Unified format adder: handles FP8 + FP6 + FP4 (FP6/FP4 are zero when disabled)
-  fpnew_mxdotp_format_adder #(
-    .SoPFixedWidth ( SOP_FIXED_WIDTH ),
-    .Fp6SumWidth ( FP6_SUM_WIDTH ),
-    .Fp4SumWidth ( FP4_SUM_WIDTH )
-  ) i_format_adder (
-    .sum_product_fp8(sum_product_fp8),
-    .sum_product_fp6(sum_product_fp6),
-    .sum_product_fp4(sum_product_fp4),
-    .sum_product(sum_product)
+  fpnew_mxdotp_accumulator_shift #(
+    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
+  ) i_accumulator_shift (
+    .accumulator_shift_amount(inp_mid_pipe_acc_shamt_q[NUM_IM_REGS]),
+    .signed_mantissa_d(inp_mid_pipe_signed_man_d_q[NUM_IM_REGS]),
+    .accumulator_shifted(accumulator_shifted),
+    .result_is_accumulator_uncond(result_is_accumulator_uncond),
+    .result_is_accumulator_if_sop_zero(result_is_accumulator_if_sop_zero),
+    .accumulator_sticky(accumulator_sticky),
+    .accumulator_remaining(accumulator_remaining)
   );
+
+  // -----------------
+  // Accumulator + SoP                  (STAGE 2)
+  // -----------------
+  logic signed [LZC_SUM_WIDTH-1:0] sum_product_accumulator_extended;
+
+  fpnew_mxdotp_fused_sop_accumulator #(
+    .LocalVectorSize ( VectorSize            ),
+    .Fp6VectorSize   ( FP6_VECTOR_SIZE_GUARDED ),
+    .Fp4VectorSize   ( FP4_VECTOR_SIZE_GUARDED ),
+    .SoPFixedWidth   ( SOP_FIXED_WIDTH       ),
+    .Fp6ProdWidth    ( FP6_PROD_SHIFT_WIDTH  ),
+    .Fp4ProdWidth    ( FP4_PROD_SHIFT_WIDTH  ),
+    .Fp6SumWidth     ( FP6_SUM_WIDTH         ),
+    .Fp4SumWidth     ( FP4_SUM_WIDTH         )
+  ) i_fused_sop_accumulator (
+    .shifted_product(shifted_product_q),
+    .fp6_shifted_product(fp6_shifted_product_q),
+    .fp4_shifted_product(fp4_shifted_product_q),
+    .accumulator_shifted(accumulator_shifted),
+    .accumulator_remaining(accumulator_remaining),
+    .sum_product_is_zero(sum_product_is_zero),
+    .sum_product_accumulator_extended(sum_product_accumulator_extended)
+  );
+
+  // NOTE: the OR/AND that used to build `result_is_accumulator` here now sits
+  // BEHIND the MID bank (see the mid pipeline below): the two verdicts are
+  // registered raw, so the 70-bit zero test drives a flop directly.
 
   // ---------------
   // Internal pipeline
   // ---------------
   // Pipeline output signals as non-arrays
-  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_q;
-  logic [SCALE_WIDTH:0]              scale_q;
+  logic signed [LZC_SUM_WIDTH-1:0]   sum_product_accumulator_extended_q;
+  logic                              accumulator_sticky_q0;
+  logic                              result_is_accumulator_q0;
+  logic                              sum_product_is_zero_q0;
+  logic [DST_EXP_WIDTH-1:0]              scale_q;
   fp_dst_t                           operand_d_q2;
-  fpnew_pkg::fp_info_t               info_d_q;
   fpnew_pkg::fp_format_e             dst_fmt_q2;
 
   // Internal pipeline signals, index i holds signal after i register stages
-  logic signed           [0:NUM_MID_REGS][FIXED_SUM_WIDTH-1:0]    mid_pipe_sum_product_q;
-  logic                  [0:NUM_MID_REGS][SCALE_WIDTH:0]          mid_pipe_scale_q;
+  logic signed           [0:NUM_MID_REGS][LZC_SUM_WIDTH-1:0]      mid_pipe_sum_pa_ext_q;
+  logic                  [0:NUM_MID_REGS]                         mid_pipe_acc_sticky_q;
+  logic                  [0:NUM_MID_REGS]                         mid_pipe_res_is_acc_uncond_q;
+  logic                  [0:NUM_MID_REGS]                         mid_pipe_res_is_acc_ifz_q;
+  logic                  [0:NUM_MID_REGS]                         mid_pipe_sop_is_zero_q;
+  logic                  [0:NUM_MID_REGS][DST_EXP_WIDTH-1:0]          mid_pipe_scale_q;
   fp_dst_t               [0:NUM_MID_REGS]                         mid_pipe_operand_d_q;
-  fpnew_pkg::fp_info_t   [0:NUM_MID_REGS]                         mid_pipe_info_d_q;
   fpnew_pkg::fp_format_e [0:NUM_MID_REGS]                         mid_pipe_dst_fmt_q;
   fpnew_pkg::roundmode_e [0:NUM_MID_REGS]                         mid_pipe_rnd_mode_q;
   logic                  [0:NUM_MID_REGS]                         mid_pipe_res_is_spec_q;
-  logic                  [0:NUM_MID_REGS][DST_WIDTH-1:0]          mid_pipe_spec_res_q;
-  fpnew_pkg::status_t    [0:NUM_MID_REGS]                         mid_pipe_spec_stat_q;
+  logic                  [0:NUM_MID_REGS][1:0]          mid_pipe_spec_res_q;
+  logic                  [0:NUM_MID_REGS]                         mid_pipe_spec_stat_q;
   TagType                [0:NUM_MID_REGS]                         mid_pipe_tag_q;
   logic                  [0:NUM_MID_REGS]                         mid_pipe_mask_q;
   AuxType                [0:NUM_MID_REGS]                         mid_pipe_aux_q;
@@ -680,10 +814,13 @@ module fpnew_mxdotp_multi
   logic [0:NUM_MID_REGS] mid_pipe_ready;
 
   // Input stage: First element of pipeline is taken from upstream logic
-  assign mid_pipe_sum_product_q[0]       = sum_product;
+  assign mid_pipe_sum_pa_ext_q[0]        = sum_product_accumulator_extended;
+  assign mid_pipe_acc_sticky_q[0]        = accumulator_sticky;
+  assign mid_pipe_res_is_acc_uncond_q[0] = result_is_accumulator_uncond;
+  assign mid_pipe_res_is_acc_ifz_q[0]    = result_is_accumulator_if_sop_zero;
+  assign mid_pipe_sop_is_zero_q[0]       = sum_product_is_zero;
   assign mid_pipe_scale_q[0]             = inp_mid_pipe_scale_q[NUM_IM_REGS];
   assign mid_pipe_operand_d_q[0]         = inp_mid_pipe_operand_d_q[NUM_IM_REGS];
-  assign mid_pipe_info_d_q[0]            = inp_mid_pipe_info_d_q[NUM_IM_REGS];
   assign mid_pipe_dst_fmt_q[0]           = inp_mid_pipe_dst_fmt_q[NUM_IM_REGS];
   assign mid_pipe_rnd_mode_q[0]          = inp_mid_pipe_rnd_mode_q[NUM_IM_REGS];
   assign mid_pipe_res_is_spec_q[0]       = inp_mid_pipe_res_is_spec_q[NUM_IM_REGS];
@@ -709,10 +846,13 @@ module fpnew_mxdotp_multi
     // Enable register if pipeline ready and a valid data item is present
     assign reg_ena = mid_pipe_ready[i] & mid_pipe_valid_q[i];
     // Generate the pipeline registers within the stages, use enable-registers
-    `FFL(mid_pipe_sum_product_q[i+1], mid_pipe_sum_product_q[i], reg_ena, '0)
+    `FFL(mid_pipe_sum_pa_ext_q[i+1],  mid_pipe_sum_pa_ext_q[i],  reg_ena, '0)
+    `FFL(mid_pipe_acc_sticky_q[i+1],  mid_pipe_acc_sticky_q[i],  reg_ena, '0)
+    `FFL(mid_pipe_res_is_acc_uncond_q[i+1], mid_pipe_res_is_acc_uncond_q[i], reg_ena, '0)
+    `FFL(mid_pipe_res_is_acc_ifz_q[i+1],    mid_pipe_res_is_acc_ifz_q[i],    reg_ena, '0)
+    `FFL(mid_pipe_sop_is_zero_q[i+1], mid_pipe_sop_is_zero_q[i], reg_ena, '0)
     `FFL(mid_pipe_scale_q[i+1],       mid_pipe_scale_q[i],       reg_ena, '0)
     `FFL(mid_pipe_operand_d_q[i+1],   mid_pipe_operand_d_q[i],   reg_ena, '0)
-    `FFL(mid_pipe_info_d_q[i+1],      mid_pipe_info_d_q[i],      reg_ena, '0)
     `FFL(mid_pipe_dst_fmt_q[i+1],     mid_pipe_dst_fmt_q[i],     reg_ena, fpnew_pkg::fp_format_e'(0))
     `FFL(mid_pipe_rnd_mode_q[i+1],    mid_pipe_rnd_mode_q[i],    reg_ena, fpnew_pkg::RNE)
     `FFL(mid_pipe_res_is_spec_q[i+1], mid_pipe_res_is_spec_q[i], reg_ena, '0)
@@ -723,57 +863,18 @@ module fpnew_mxdotp_multi
     `FFL(mid_pipe_aux_q[i+1],         mid_pipe_aux_q[i],         reg_ena, AuxType'('0))
   end
   // Output stage: assign selected pipe outputs to signals for later use
-  assign sum_product_q       = mid_pipe_sum_product_q[NUM_MID_REGS];
-  assign scale_q             = mid_pipe_scale_q[NUM_MID_REGS];
-  assign operand_d_q2        = mid_pipe_operand_d_q[NUM_MID_REGS];
-  assign info_d_q            = mid_pipe_info_d_q[NUM_MID_REGS];
-  assign dst_fmt_q2          = mid_pipe_dst_fmt_q[NUM_MID_REGS];
-
-  // -----------------------------
-  // Accumulator shift data path
-  // -----------------------------
-  logic result_is_accumulator;
-  logic accumulator_is_right_shifted;
-
-  logic signed [9:0] accumulator_right_shift_amount;
-  logic signed [FIXED_SUM_WIDTH-1:0] accumulator_shifted;
-  logic signed [DST_PRECISION_BITS :0] signed_mantissa_d;
-  logic accumulator_sticky;
-  logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining;
-
-  fpnew_mxdotp_accumulator_shift #(
-    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
-  ) i_accumulator_shift (
-    .sum_product(sum_product_q),
-    .scale(scale_q),
-    .operand_d(operand_d_q2),
-    .info_d(info_d_q),
-    .dst_fmt(dst_fmt_q2),
-    .accumulator_is_right_shifted(accumulator_is_right_shifted),
-    .accumulator_right_shift_amount(accumulator_right_shift_amount),
-    .accumulator_shifted(accumulator_shifted),
-    .result_is_accumulator(result_is_accumulator),
-    .accumulator_sticky(accumulator_sticky),
-    .signed_mantissa_d(signed_mantissa_d),
-    .accumulator_remaining(accumulator_remaining)
-  );
-
-  // -----------------
-  // Accumulator + SoP
-  // -----------------
-  logic signed [LZC_SUM_WIDTH-1:0] sum_product_accumulator_extended;
-
-  fpnew_mxdotp_add_accumulator_sop #(
-    .SoPFixedWidth  ( SOP_FIXED_WIDTH )
-  ) i_add_accumulator_sop (
-    .sum_product(sum_product_q),
-    .accumulator_shifted(accumulator_shifted),
-    .accumulator_remaining(accumulator_remaining),
-    .sum_product_accumulator_extended(sum_product_accumulator_extended)
-  );
+  assign sum_product_accumulator_extended_q = mid_pipe_sum_pa_ext_q[NUM_MID_REGS];
+  assign accumulator_sticky_q0              = mid_pipe_acc_sticky_q[NUM_MID_REGS];
+  assign result_is_accumulator_q0           = mid_pipe_res_is_acc_uncond_q[NUM_MID_REGS]
+                                           | (mid_pipe_res_is_acc_ifz_q[NUM_MID_REGS]
+                                              & mid_pipe_sop_is_zero_q[NUM_MID_REGS]);
+  assign sum_product_is_zero_q0             = mid_pipe_sop_is_zero_q[NUM_MID_REGS];
+  assign scale_q                            = mid_pipe_scale_q[NUM_MID_REGS];
+  assign operand_d_q2                       = mid_pipe_operand_d_q[NUM_MID_REGS];
+  assign dst_fmt_q2                         = mid_pipe_dst_fmt_q[NUM_MID_REGS];
 
   // ----------------------------------
-  // Normalization 1: Two's complement
+  // Normalization 1: Two's complement  (STAGE 3)
   // ----------------------------------
   logic final_sign;
   logic [LZC_SUM_WIDTH-1:0] sum_magnitude;
@@ -781,11 +882,7 @@ module fpnew_mxdotp_multi
   fpnew_mxdotp_twos_compl #(
     .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_twos_compl (
-    .sum_product_accumulator_extended ( sum_product_accumulator_extended ),
-    .signed_mantissa_d                ( signed_mantissa_d                ),
-    .accumulator_is_right_shifted     ( accumulator_is_right_shifted     ),
-    .accumulator_right_shift_amount   ( accumulator_right_shift_amount   ),
-    .accumulator_sticky               ( accumulator_sticky               ),
+    .sum_product_accumulator_extended ( sum_product_accumulator_extended_q ),
     .final_sign                       ( final_sign                       ),
     .sum_magnitude                    ( sum_magnitude                    )
   );
@@ -795,21 +892,21 @@ module fpnew_mxdotp_multi
   // -------------------------
   // Pipeline output signals as non-arrays
   logic [LZC_SUM_WIDTH-1:0] sum_magnitude_q;
-  logic [SCALE_WIDTH:0]     scale_q2;
+  logic [DST_EXP_WIDTH-1:0]     scale_q2;
 
   // MO-early pipeline signals, index i holds signal after i register stages
   logic                  [0:NUM_MO_EARLY_REGS][LZC_SUM_WIDTH-1:0]   mo_early_pipe_sum_magnitude_q;
   logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_final_sign_q;
-  logic                  [0:NUM_MO_EARLY_REGS][SCALE_WIDTH:0]       mo_early_pipe_scale_q;
+  logic                  [0:NUM_MO_EARLY_REGS][DST_EXP_WIDTH-1:0]       mo_early_pipe_scale_q;
   logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_acc_sticky_q;
   logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_res_is_acc_q;
-  logic                  [0:NUM_MO_EARLY_REGS][FIXED_SUM_WIDTH-1:0] mo_early_pipe_sum_product_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_sop_is_zero_q;
   fp_dst_t               [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_operand_d_q;
   fpnew_pkg::fp_format_e [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_dst_fmt_q;
   fpnew_pkg::roundmode_e [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_rnd_mode_q;
   logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_res_is_spec_q;
-  logic                  [0:NUM_MO_EARLY_REGS][DST_WIDTH-1:0]       mo_early_pipe_spec_res_q;
-  fpnew_pkg::status_t    [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_spec_stat_q;
+  logic                  [0:NUM_MO_EARLY_REGS][1:0]       mo_early_pipe_spec_res_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_spec_stat_q;
   TagType                [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_tag_q;
   logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_mask_q;
   AuxType                [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_aux_q;
@@ -821,9 +918,9 @@ module fpnew_mxdotp_multi
   assign mo_early_pipe_sum_magnitude_q[0] = sum_magnitude;
   assign mo_early_pipe_final_sign_q[0]    = final_sign;
   assign mo_early_pipe_scale_q[0]         = scale_q;
-  assign mo_early_pipe_acc_sticky_q[0]    = accumulator_sticky;
-  assign mo_early_pipe_res_is_acc_q[0]    = result_is_accumulator;
-  assign mo_early_pipe_sum_product_q[0]   = sum_product_q;
+  assign mo_early_pipe_acc_sticky_q[0]    = accumulator_sticky_q0;
+  assign mo_early_pipe_res_is_acc_q[0]    = result_is_accumulator_q0;
+  assign mo_early_pipe_sop_is_zero_q[0]   = sum_product_is_zero_q0;
   assign mo_early_pipe_operand_d_q[0]     = operand_d_q2;
   assign mo_early_pipe_dst_fmt_q[0]       = dst_fmt_q2;
   assign mo_early_pipe_rnd_mode_q[0]      = mid_pipe_rnd_mode_q[NUM_MID_REGS];
@@ -855,7 +952,7 @@ module fpnew_mxdotp_multi
     `FFL(mo_early_pipe_scale_q[i+1],         mo_early_pipe_scale_q[i],         reg_ena, '0)
     `FFL(mo_early_pipe_acc_sticky_q[i+1],    mo_early_pipe_acc_sticky_q[i],    reg_ena, '0)
     `FFL(mo_early_pipe_res_is_acc_q[i+1],    mo_early_pipe_res_is_acc_q[i],    reg_ena, '0)
-    `FFL(mo_early_pipe_sum_product_q[i+1],   mo_early_pipe_sum_product_q[i],   reg_ena, '0)
+    `FFL(mo_early_pipe_sop_is_zero_q[i+1],   mo_early_pipe_sop_is_zero_q[i],   reg_ena, '0)
     `FFL(mo_early_pipe_operand_d_q[i+1],     mo_early_pipe_operand_d_q[i],     reg_ena, '0)
     `FFL(mo_early_pipe_dst_fmt_q[i+1],       mo_early_pipe_dst_fmt_q[i],       reg_ena, fpnew_pkg::fp_format_e'(0))
     `FFL(mo_early_pipe_rnd_mode_q[i+1],      mo_early_pipe_rnd_mode_q[i],      reg_ena, fpnew_pkg::RNE)
@@ -876,10 +973,16 @@ module fpnew_mxdotp_multi
   logic signed [LZC_RESULT_WIDTH:0] leading_zero_count_sgn;
   logic                             lzc_zeroes;
 
+  // The pending +1 of the two's complement (see fpnew_mxdotp_twos_compl)
+  logic mag_inc;
+  assign mag_inc = mo_early_pipe_final_sign_q[NUM_MO_EARLY_REGS]
+                 & ~mo_early_pipe_acc_sticky_q[NUM_MO_EARLY_REGS];
+
   fpnew_mxdotp_norm_lzc #(
     .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_norm_lzc (
-    .sum_magnitude         ( sum_magnitude_q        ),
+    .sum_magnitude_ones    ( sum_magnitude_q        ),
+    .mag_inc               ( mag_inc                ),
     .leading_zero_count_sgn( leading_zero_count_sgn ),
     .lzc_zeroes            ( lzc_zeroes             )
   );
@@ -891,14 +994,17 @@ module fpnew_mxdotp_multi
   logic [LZC_SUM_WIDTH-1:0]         sum_magnitude_q2;
   logic signed [LZC_RESULT_WIDTH:0] leading_zero_count_sgn_q;
   logic                             lzc_zeroes_q;
-  logic [SCALE_WIDTH:0]             scale_q3;
+  logic [DST_EXP_WIDTH-1:0]             scale_q3;
   logic                             final_sign_q;
   logic                             accumulator_sticky_q;
   logic                             result_is_accumulator_q;
-  logic [FIXED_SUM_WIDTH-1:0]       sum_product_q2;
+  logic                             sop_is_zero_q2;
   fp_dst_t                          operand_d_q3;
   fpnew_pkg::fp_format_e            dst_fmt_q3;
   fpnew_pkg::roundmode_e            rnd_mode_q;
+  logic                             result_is_special_raw_q;
+  logic [1:0]                       special_code_q;
+  logic                             special_nv_q;
   logic                             result_is_special_q;
   logic [DST_WIDTH-1:0]             special_result_q;
   fpnew_pkg::status_t               special_status_q;
@@ -907,17 +1013,17 @@ module fpnew_mxdotp_multi
   logic                  [0:NUM_MO_LATE_REGS][LZC_SUM_WIDTH-1:0]      mo_late_pipe_sum_magnitude_q;
   logic signed           [0:NUM_MO_LATE_REGS][LZC_RESULT_WIDTH:0]     mo_late_pipe_lzc_count_sgn_q;
   logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_lzc_zeroes_q;
-  logic                  [0:NUM_MO_LATE_REGS][SCALE_WIDTH:0]          mo_late_pipe_scale_q;
+  logic                  [0:NUM_MO_LATE_REGS][DST_EXP_WIDTH-1:0]          mo_late_pipe_scale_q;
   logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_final_sign_q;
   logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_acc_sticky_q;
   logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_res_is_acc_q;
-  logic                  [0:NUM_MO_LATE_REGS][FIXED_SUM_WIDTH-1:0]    mo_late_pipe_sum_product_q;
+  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_sop_is_zero_q;
   fp_dst_t               [0:NUM_MO_LATE_REGS]                         mo_late_pipe_operand_d_q;
   fpnew_pkg::fp_format_e [0:NUM_MO_LATE_REGS]                         mo_late_pipe_dst_fmt_q;
   fpnew_pkg::roundmode_e [0:NUM_MO_LATE_REGS]                         mo_late_pipe_rnd_mode_q;
   logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_res_is_spec_q;
-  logic                  [0:NUM_MO_LATE_REGS][DST_WIDTH-1:0]          mo_late_pipe_spec_res_q;
-  fpnew_pkg::status_t    [0:NUM_MO_LATE_REGS]                         mo_late_pipe_spec_stat_q;
+  logic                  [0:NUM_MO_LATE_REGS][1:0]          mo_late_pipe_spec_res_q;
+  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_spec_stat_q;
   TagType                [0:NUM_MO_LATE_REGS]                         mo_late_pipe_tag_q;
   logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_mask_q;
   AuxType                [0:NUM_MO_LATE_REGS]                         mo_late_pipe_aux_q;
@@ -933,7 +1039,7 @@ module fpnew_mxdotp_multi
   assign mo_late_pipe_final_sign_q[0]           = mo_early_pipe_final_sign_q[NUM_MO_EARLY_REGS];
   assign mo_late_pipe_acc_sticky_q[0]           = mo_early_pipe_acc_sticky_q[NUM_MO_EARLY_REGS];
   assign mo_late_pipe_res_is_acc_q[0]           = mo_early_pipe_res_is_acc_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_sum_product_q[0]          = mo_early_pipe_sum_product_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_sop_is_zero_q[0]          = mo_early_pipe_sop_is_zero_q[NUM_MO_EARLY_REGS];
   assign mo_late_pipe_operand_d_q[0]            = mo_early_pipe_operand_d_q[NUM_MO_EARLY_REGS];
   assign mo_late_pipe_dst_fmt_q[0]              = mo_early_pipe_dst_fmt_q[NUM_MO_EARLY_REGS];
   assign mo_late_pipe_rnd_mode_q[0]             = mo_early_pipe_rnd_mode_q[NUM_MO_EARLY_REGS];
@@ -967,7 +1073,7 @@ module fpnew_mxdotp_multi
     `FFL(mo_late_pipe_final_sign_q[i+1],    mo_late_pipe_final_sign_q[i],    reg_ena, '0)
     `FFL(mo_late_pipe_acc_sticky_q[i+1],    mo_late_pipe_acc_sticky_q[i],    reg_ena, '0)
     `FFL(mo_late_pipe_res_is_acc_q[i+1],    mo_late_pipe_res_is_acc_q[i],    reg_ena, '0)
-    `FFL(mo_late_pipe_sum_product_q[i+1],   mo_late_pipe_sum_product_q[i],   reg_ena, '0)
+    `FFL(mo_late_pipe_sop_is_zero_q[i+1],   mo_late_pipe_sop_is_zero_q[i],   reg_ena, '0)
     `FFL(mo_late_pipe_operand_d_q[i+1],     mo_late_pipe_operand_d_q[i],     reg_ena, '0)
     `FFL(mo_late_pipe_dst_fmt_q[i+1],       mo_late_pipe_dst_fmt_q[i],       reg_ena, fpnew_pkg::fp_format_e'(0))
     `FFL(mo_late_pipe_rnd_mode_q[i+1],      mo_late_pipe_rnd_mode_q[i],      reg_ena, fpnew_pkg::RNE)
@@ -986,17 +1092,32 @@ module fpnew_mxdotp_multi
   assign final_sign_q              = mo_late_pipe_final_sign_q[NUM_MO_LATE_REGS];
   assign accumulator_sticky_q      = mo_late_pipe_acc_sticky_q[NUM_MO_LATE_REGS];
   assign result_is_accumulator_q   = mo_late_pipe_res_is_acc_q[NUM_MO_LATE_REGS];
-  assign sum_product_q2            = mo_late_pipe_sum_product_q[NUM_MO_LATE_REGS];
+  assign sop_is_zero_q2            = mo_late_pipe_sop_is_zero_q[NUM_MO_LATE_REGS];
   assign operand_d_q3              = mo_late_pipe_operand_d_q[NUM_MO_LATE_REGS];
   assign dst_fmt_q3                = mo_late_pipe_dst_fmt_q[NUM_MO_LATE_REGS];
   assign rnd_mode_q                = mo_late_pipe_rnd_mode_q[NUM_MO_LATE_REGS];
-  assign result_is_special_q       = mo_late_pipe_res_is_spec_q[NUM_MO_LATE_REGS];
-  assign special_result_q          = mo_late_pipe_spec_res_q[NUM_MO_LATE_REGS];
-  assign special_status_q          = mo_late_pipe_spec_stat_q[NUM_MO_LATE_REGS];
+  assign result_is_special_raw_q   = mo_late_pipe_res_is_spec_q[NUM_MO_LATE_REGS];
+  assign special_code_q            = mo_late_pipe_spec_res_q[NUM_MO_LATE_REGS];
+  assign special_nv_q              = mo_late_pipe_spec_stat_q[NUM_MO_LATE_REGS];
+
+  // Rebuild the 32-bit special result / status word from the carried verdict.
+  fpnew_mxdotp_special_assemble #(
+    .FpDstFmtConfig ( FpDstFmtConfig )
+  ) i_special_assemble (
+    .result_is_special_raw ( result_is_special_raw_q ),
+    .special_nv            ( special_nv_q            ),
+    .special_is_inf        ( special_code_q[1]       ),
+    .special_inf_sign      ( special_code_q[0]       ),
+    .dst_fmt               ( mo_late_pipe_dst_fmt_q[NUM_MO_LATE_REGS] ),
+    .special_result        ( special_result_q        ),
+    .special_status        ( special_status_q        ),
+    .result_is_special     ( result_is_special_q     )
+  );
 
   // -------------------------------------------
   // Normalization 3: Shift + mantissa assembly
   // -------------------------------------------
+  logic [LZC_SUM_WIDTH-1:0]        sum_magnitude_true;
   logic [DST_PRECISION_BITS-1:0]   final_mantissa;
   logic signed [DST_EXP_WIDTH-1:0] final_exponent;
   logic                            sticky_after_norm;
@@ -1004,11 +1125,13 @@ module fpnew_mxdotp_multi
   fpnew_mxdotp_norm_finalize #(
     .SoPFixedWidth  ( SOP_FIXED_WIDTH )
   ) i_norm_finalize (
-    .sum_magnitude          ( sum_magnitude_q2         ),
+    .sum_magnitude_ones     ( sum_magnitude_q2         ),
     .leading_zero_count_sgn ( leading_zero_count_sgn_q ),
     .lzc_zeroes             ( lzc_zeroes_q             ),
-    .scale                  ( scale_q3                 ),
+    .exponent_major         ( scale_q3                 ),
+    .final_sign             ( final_sign_q             ),
     .accumulator_sticky     ( accumulator_sticky_q     ),
+    .sum_magnitude_o        ( sum_magnitude_true       ),
     .final_mantissa         ( final_mantissa           ),
     .final_exponent         ( final_exponent           ),
     .sticky_after_norm      ( sticky_after_norm        )
@@ -1033,7 +1156,7 @@ module fpnew_mxdotp_multi
     .final_mantissa(final_mantissa),
     .final_exponent(final_exponent),
     .sticky_after_norm(sticky_after_norm),
-    .sum_magnitude(sum_magnitude_q2),
+    .sum_magnitude(sum_magnitude_true),
     .dst_fmt(dst_fmt_q3),
     .rnd_mode(rnd_mode_q),
     .round_sticky_bits(round_sticky_bits),
@@ -1064,7 +1187,7 @@ module fpnew_mxdotp_multi
   assign accumulator_status.DZ = 1'b0;
   assign accumulator_status.OF = 1'b0;
   assign accumulator_status.UF = 1'b0;
-  assign accumulator_status.NX = (sum_product_q2 != '0);
+  assign accumulator_status.NX = ~sop_is_zero_q2;
 
   assign accumulator_result = (dst_fmt_q3 == fpnew_pkg::FP16ALT) ?
                               {16'hFFFF, operand_d_q3[31:16]} :
@@ -1074,11 +1197,22 @@ module fpnew_mxdotp_multi
   logic [DST_WIDTH-1:0] result_d;
   fpnew_pkg::status_t   status_d;
 
-  // Select output depending on special case detection
-  assign result_d = result_is_special_q ? special_result_q :
-                    (result_is_accumulator_q ? accumulator_result : regular_result);
-  assign status_d = result_is_special_q ? special_status_q :
-                    (result_is_accumulator_q ? accumulator_status : regular_status);
+  // Select output depending on special case detection.
+  //
+  // Both selects are EARLY (they come straight out of the MO-late bank) while
+  // `regular_*` is the tail of the rounder, so the original nesting put TWO
+  // 2:1 levels in series behind the latest signal in the design.  Collapsing
+  // the two early arms into one early mux leaves exactly one 2:1 level on the
+  // late arm.  Same function: special wins, then accumulator, then regular.
+  logic                 use_regular;
+  logic [DST_WIDTH-1:0] early_result;
+  fpnew_pkg::status_t   early_status;
+  assign use_regular  = ~result_is_special_q & ~result_is_accumulator_q;
+  assign early_result = result_is_special_q ? special_result_q : accumulator_result;
+  assign early_status = result_is_special_q ? special_status_q : accumulator_status;
+
+  assign result_d = use_regular ? regular_result : early_result;
+  assign status_d = use_regular ? regular_status : early_status;
 
   // ----------------
   // Output Pipeline

--- a/src/fpnew_mxdotp_multi.sv
+++ b/src/fpnew_mxdotp_multi.sv
@@ -480,9 +480,9 @@ module fpnew_mxdotp_multi
   // NOTE: these now carry the COMPLETE alignment shift amount (unsigned), not
   // just the product exponent -- the constant offset the alignment stage used
   // to add is folded into the stage-1 exponent adder (see product_exponent).
-  logic [VectorSize-1:0][EXP_WIDTH+1-1:0]          exponent_product;
-  logic [FP6_VECTOR_SIZE_GUARDED-1:0][6-1:0]               fp6_exponent_product;
-  logic [FP4_VECTOR_SIZE_GUARDED-1:0][3-1:0]               fp4_exponent_product;
+  logic [VectorSize-1:0][EXP_WIDTH+1-1:0] exponent_product;
+  logic [FP6_VECTOR_SIZE_GUARDED-1:0][6-1:0] fp6_exponent_product;
+  logic [FP4_VECTOR_SIZE_GUARDED-1:0][3-1:0] fp4_exponent_product;
 
   if (FpSrcFmtConfig[fpnew_pkg::FP8] || FpSrcFmtConfig[fpnew_pkg::FP8ALT]) begin : fp8_product_exponent
     fpnew_mxdotp_product_exponent #(
@@ -574,52 +574,52 @@ module fpnew_mxdotp_multi
   logic signed [FP4_VECTOR_SIZE_GUARDED-1:0][FP4_PROD_SHIFT_WIDTH-1:0] fp4_shifted_product_q;
 
   // Inp-mid pipeline signals, index i holds signal after i register stages
-  logic signed           [0:NUM_IM_REGS][VectorSize-1:0][PROD_BITS-1:0]                 inp_mid_pipe_product_q;
-  logic signed           [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][2*FP6_PREC_BITS:0]        inp_mid_pipe_fp6_product_q;
-  logic signed           [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][2*FP4_PREC_BITS:0]        inp_mid_pipe_fp4_product_q;
-  logic                  [0:NUM_IM_REGS][VectorSize-1:0][EXP_WIDTH+1-1:0]               inp_mid_pipe_exp_prod_q;
-  logic                  [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][6-1:0]                     inp_mid_pipe_fp6_exp_prod_q;
-  logic                  [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][3-1:0]                     inp_mid_pipe_fp4_exp_prod_q;
-  fpnew_pkg::int_format_e[0:NUM_IM_REGS]                                                inp_mid_pipe_int_fmt_q;
-  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_src_is_int_q;
-  fpnew_pkg::fp_format_e [0:NUM_IM_REGS]                                                inp_mid_pipe_dst_fmt_q;
-  logic                  [0:NUM_IM_REGS][DST_EXP_WIDTH-1:0]                                 inp_mid_pipe_scale_q;
-  fp_dst_t               [0:NUM_IM_REGS]                                                inp_mid_pipe_operand_d_q;
-  logic signed           [0:NUM_IM_REGS][9:0]                                           inp_mid_pipe_acc_shamt_q;
-  logic signed           [0:NUM_IM_REGS][DST_PRECISION_BITS :0]                         inp_mid_pipe_signed_man_d_q;
-  fpnew_pkg::roundmode_e [0:NUM_IM_REGS]                                                inp_mid_pipe_rnd_mode_q;
-  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_res_is_spec_q;
-  logic                  [0:NUM_IM_REGS][1:0]                                 inp_mid_pipe_spec_res_q;
-  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_spec_stat_q;
-  TagType                [0:NUM_IM_REGS]                                                inp_mid_pipe_tag_q;
-  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_mask_q;
-  AuxType                [0:NUM_IM_REGS]                                                inp_mid_pipe_aux_q;
-  logic                  [0:NUM_IM_REGS]                                                inp_mid_pipe_valid_q;
+  logic signed            [0:NUM_IM_REGS][VectorSize-1:0][PROD_BITS-1:0]                  inp_mid_pipe_product_q;
+  logic signed            [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][2*FP6_PREC_BITS:0] inp_mid_pipe_fp6_product_q;
+  logic signed            [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][2*FP4_PREC_BITS:0] inp_mid_pipe_fp4_product_q;
+  logic                   [0:NUM_IM_REGS][VectorSize-1:0][EXP_WIDTH+1-1:0]                inp_mid_pipe_exp_prod_q;
+  logic                   [0:NUM_IM_REGS][FP6_VECTOR_SIZE_GUARDED-1:0][6-1:0]             inp_mid_pipe_fp6_exp_prod_q;
+  logic                   [0:NUM_IM_REGS][FP4_VECTOR_SIZE_GUARDED-1:0][3-1:0]             inp_mid_pipe_fp4_exp_prod_q;
+  fpnew_pkg::int_format_e [0:NUM_IM_REGS]                                                 inp_mid_pipe_int_fmt_q;
+  logic                   [0:NUM_IM_REGS]                                                 inp_mid_pipe_src_is_int_q;
+  fpnew_pkg::fp_format_e  [0:NUM_IM_REGS]                                                 inp_mid_pipe_dst_fmt_q;
+  logic                   [0:NUM_IM_REGS][DST_EXP_WIDTH-1:0]                              inp_mid_pipe_scale_q;
+  fp_dst_t                [0:NUM_IM_REGS]                                                 inp_mid_pipe_operand_d_q;
+  logic signed            [0:NUM_IM_REGS][9:0]                                            inp_mid_pipe_acc_shamt_q;
+  logic signed            [0:NUM_IM_REGS][DST_PRECISION_BITS :0]                          inp_mid_pipe_signed_man_d_q;
+  fpnew_pkg::roundmode_e  [0:NUM_IM_REGS]                                                 inp_mid_pipe_rnd_mode_q;
+  logic                   [0:NUM_IM_REGS]                                                 inp_mid_pipe_res_is_spec_q;
+  logic                   [0:NUM_IM_REGS][1:0]                                            inp_mid_pipe_spec_res_q;
+  logic                   [0:NUM_IM_REGS]                                                 inp_mid_pipe_spec_stat_q;
+  TagType                 [0:NUM_IM_REGS]                                                 inp_mid_pipe_tag_q;
+  logic                   [0:NUM_IM_REGS]                                                 inp_mid_pipe_mask_q;
+  AuxType                 [0:NUM_IM_REGS]                                                 inp_mid_pipe_aux_q;
+  logic                   [0:NUM_IM_REGS]                                                 inp_mid_pipe_valid_q;
   // Ready signal is combinatorial for all stages
-  logic [0:NUM_IM_REGS]                                                                 inp_mid_pipe_ready;
+  logic [0:NUM_IM_REGS]                                                                   inp_mid_pipe_ready;
 
   // Input stage: First element of pipeline is taken from upstream logic
-  assign inp_mid_pipe_product_q[0]             = product_signed;
-  assign inp_mid_pipe_fp6_product_q[0]         = fp6_product_signed;
-  assign inp_mid_pipe_fp4_product_q[0]         = fp4_product_signed;
-  assign inp_mid_pipe_exp_prod_q[0]            = exponent_product;
-  assign inp_mid_pipe_fp6_exp_prod_q[0]        = fp6_exponent_product;
-  assign inp_mid_pipe_fp4_exp_prod_q[0]        = fp4_exponent_product;
-  assign inp_mid_pipe_int_fmt_q[0]             = int_fmt_q;
-  assign inp_mid_pipe_src_is_int_q[0]          = src_is_int;
-  assign inp_mid_pipe_dst_fmt_q[0]             = inp_pipe_dst_fmt_q[NUM_INP_REGS];
-  assign inp_mid_pipe_scale_q[0]               = exponent_major;
-  assign inp_mid_pipe_operand_d_q[0]           = operand_d;
-  assign inp_mid_pipe_acc_shamt_q[0]           = accumulator_shift_amount_d;
-  assign inp_mid_pipe_signed_man_d_q[0]        = signed_mantissa_d_d;
-  assign inp_mid_pipe_rnd_mode_q[0]            = inp_pipe_rnd_mode_q[NUM_INP_REGS];
-  assign inp_mid_pipe_res_is_spec_q[0]         = special_raw[3];
-  assign inp_mid_pipe_spec_res_q[0]            = special_raw[1:0];
-  assign inp_mid_pipe_spec_stat_q[0]           = special_raw[2];
-  assign inp_mid_pipe_tag_q[0]                 = inp_pipe_tag_q[NUM_INP_REGS];
-  assign inp_mid_pipe_mask_q[0]                = inp_pipe_mask_q[NUM_INP_REGS];
-  assign inp_mid_pipe_aux_q[0]                 = inp_pipe_aux_q[NUM_INP_REGS];
-  assign inp_mid_pipe_valid_q[0]               = inp_pipe_valid_q[NUM_INP_REGS];
+  assign inp_mid_pipe_product_q[0]      = product_signed;
+  assign inp_mid_pipe_fp6_product_q[0]  = fp6_product_signed;
+  assign inp_mid_pipe_fp4_product_q[0]  = fp4_product_signed;
+  assign inp_mid_pipe_exp_prod_q[0]     = exponent_product;
+  assign inp_mid_pipe_fp6_exp_prod_q[0] = fp6_exponent_product;
+  assign inp_mid_pipe_fp4_exp_prod_q[0] = fp4_exponent_product;
+  assign inp_mid_pipe_int_fmt_q[0]      = int_fmt_q;
+  assign inp_mid_pipe_src_is_int_q[0]   = src_is_int;
+  assign inp_mid_pipe_dst_fmt_q[0]      = inp_pipe_dst_fmt_q[NUM_INP_REGS];
+  assign inp_mid_pipe_scale_q[0]        = exponent_major;
+  assign inp_mid_pipe_operand_d_q[0]    = operand_d;
+  assign inp_mid_pipe_acc_shamt_q[0]    = accumulator_shift_amount_d;
+  assign inp_mid_pipe_signed_man_d_q[0] = signed_mantissa_d_d;
+  assign inp_mid_pipe_rnd_mode_q[0]     = inp_pipe_rnd_mode_q[NUM_INP_REGS];
+  assign inp_mid_pipe_res_is_spec_q[0]  = special_raw[3];
+  assign inp_mid_pipe_spec_res_q[0]     = special_raw[1:0];
+  assign inp_mid_pipe_spec_stat_q[0]    = special_raw[2];
+  assign inp_mid_pipe_tag_q[0]          = inp_pipe_tag_q[NUM_INP_REGS];
+  assign inp_mid_pipe_mask_q[0]         = inp_pipe_mask_q[NUM_INP_REGS];
+  assign inp_mid_pipe_aux_q[0]          = inp_pipe_aux_q[NUM_INP_REGS];
+  assign inp_mid_pipe_valid_q[0]        = inp_pipe_valid_q[NUM_INP_REGS];
   // Input stage: Propagate pipeline ready signal to input pipe
   assign inp_pipe_ready[NUM_INP_REGS]          = inp_mid_pipe_ready[0];
 
@@ -786,32 +786,32 @@ module fpnew_mxdotp_multi
   // ---------------
   // Pipeline output signals as non-arrays
   logic signed [LZC_SUM_WIDTH-1:0]   sum_product_accumulator_extended_q;
-  logic                              accumulator_sticky_q0;
-  logic                              result_is_accumulator_q0;
-  logic                              sum_product_is_zero_q0;
-  logic [DST_EXP_WIDTH-1:0]              scale_q;
+  logic                              accumulator_sticky_q;
+  logic                              result_is_accumulator_q;
+  logic                              sum_product_is_zero_q;
+  logic [DST_EXP_WIDTH-1:0]          scale_q;
   fp_dst_t                           operand_d_q2;
   fpnew_pkg::fp_format_e             dst_fmt_q2;
 
   // Internal pipeline signals, index i holds signal after i register stages
-  logic signed           [0:NUM_MID_REGS][LZC_SUM_WIDTH-1:0]      mid_pipe_sum_pa_ext_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_acc_sticky_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_res_is_acc_uncond_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_res_is_acc_ifz_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_sop_is_zero_q;
-  logic                  [0:NUM_MID_REGS][DST_EXP_WIDTH-1:0]          mid_pipe_scale_q;
-  fp_dst_t               [0:NUM_MID_REGS]                         mid_pipe_operand_d_q;
-  fpnew_pkg::fp_format_e [0:NUM_MID_REGS]                         mid_pipe_dst_fmt_q;
-  fpnew_pkg::roundmode_e [0:NUM_MID_REGS]                         mid_pipe_rnd_mode_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_res_is_spec_q;
-  logic                  [0:NUM_MID_REGS][1:0]          mid_pipe_spec_res_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_spec_stat_q;
-  TagType                [0:NUM_MID_REGS]                         mid_pipe_tag_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_mask_q;
-  AuxType                [0:NUM_MID_REGS]                         mid_pipe_aux_q;
-  logic                  [0:NUM_MID_REGS]                         mid_pipe_valid_q;
+  logic signed           [0:NUM_MID_REGS][LZC_SUM_WIDTH-1:0] mid_pipe_sum_pa_ext_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_acc_sticky_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_res_is_acc_uncond_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_res_is_acc_ifz_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_sop_is_zero_q;
+  logic                  [0:NUM_MID_REGS][DST_EXP_WIDTH-1:0] mid_pipe_scale_q;
+  fp_dst_t               [0:NUM_MID_REGS]                    mid_pipe_operand_d_q;
+  fpnew_pkg::fp_format_e [0:NUM_MID_REGS]                    mid_pipe_dst_fmt_q;
+  fpnew_pkg::roundmode_e [0:NUM_MID_REGS]                    mid_pipe_rnd_mode_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_res_is_spec_q;
+  logic                  [0:NUM_MID_REGS][1:0]               mid_pipe_spec_res_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_spec_stat_q;
+  TagType                [0:NUM_MID_REGS]                    mid_pipe_tag_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_mask_q;
+  AuxType                [0:NUM_MID_REGS]                    mid_pipe_aux_q;
+  logic                  [0:NUM_MID_REGS]                    mid_pipe_valid_q;
   // Ready signal is combinatorial for all stages
-  logic [0:NUM_MID_REGS] mid_pipe_ready;
+  logic [0:NUM_MID_REGS]                                     mid_pipe_ready;
 
   // Input stage: First element of pipeline is taken from upstream logic
   assign mid_pipe_sum_pa_ext_q[0]        = sum_product_accumulator_extended;
@@ -864,11 +864,11 @@ module fpnew_mxdotp_multi
   end
   // Output stage: assign selected pipe outputs to signals for later use
   assign sum_product_accumulator_extended_q = mid_pipe_sum_pa_ext_q[NUM_MID_REGS];
-  assign accumulator_sticky_q0              = mid_pipe_acc_sticky_q[NUM_MID_REGS];
-  assign result_is_accumulator_q0           = mid_pipe_res_is_acc_uncond_q[NUM_MID_REGS]
-                                           | (mid_pipe_res_is_acc_ifz_q[NUM_MID_REGS]
-                                              & mid_pipe_sop_is_zero_q[NUM_MID_REGS]);
-  assign sum_product_is_zero_q0             = mid_pipe_sop_is_zero_q[NUM_MID_REGS];
+  assign accumulator_sticky_q               = mid_pipe_acc_sticky_q[NUM_MID_REGS];
+  assign result_is_accumulator_q            = mid_pipe_res_is_acc_uncond_q[NUM_MID_REGS]
+                                            | (mid_pipe_res_is_acc_ifz_q[NUM_MID_REGS]
+                                               & mid_pipe_sop_is_zero_q[NUM_MID_REGS]);
+  assign sum_product_is_zero_q              = mid_pipe_sop_is_zero_q[NUM_MID_REGS];
   assign scale_q                            = mid_pipe_scale_q[NUM_MID_REGS];
   assign operand_d_q2                       = mid_pipe_operand_d_q[NUM_MID_REGS];
   assign dst_fmt_q2                         = mid_pipe_dst_fmt_q[NUM_MID_REGS];
@@ -895,32 +895,32 @@ module fpnew_mxdotp_multi
   logic [DST_EXP_WIDTH-1:0]     scale_q2;
 
   // MO-early pipeline signals, index i holds signal after i register stages
-  logic                  [0:NUM_MO_EARLY_REGS][LZC_SUM_WIDTH-1:0]   mo_early_pipe_sum_magnitude_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_final_sign_q;
-  logic                  [0:NUM_MO_EARLY_REGS][DST_EXP_WIDTH-1:0]       mo_early_pipe_scale_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_acc_sticky_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_res_is_acc_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_sop_is_zero_q;
-  fp_dst_t               [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_operand_d_q;
-  fpnew_pkg::fp_format_e [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_dst_fmt_q;
-  fpnew_pkg::roundmode_e [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_rnd_mode_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_res_is_spec_q;
-  logic                  [0:NUM_MO_EARLY_REGS][1:0]       mo_early_pipe_spec_res_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_spec_stat_q;
-  TagType                [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_tag_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_mask_q;
-  AuxType                [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_aux_q;
-  logic                  [0:NUM_MO_EARLY_REGS]                      mo_early_pipe_valid_q;
+  logic                  [0:NUM_MO_EARLY_REGS][LZC_SUM_WIDTH-1:0] mo_early_pipe_sum_magnitude_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_final_sign_q;
+  logic                  [0:NUM_MO_EARLY_REGS][DST_EXP_WIDTH-1:0] mo_early_pipe_scale_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_acc_sticky_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_res_is_acc_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_sop_is_zero_q;
+  fp_dst_t               [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_operand_d_q;
+  fpnew_pkg::fp_format_e [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_dst_fmt_q;
+  fpnew_pkg::roundmode_e [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_rnd_mode_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_res_is_spec_q;
+  logic                  [0:NUM_MO_EARLY_REGS][1:0]               mo_early_pipe_spec_res_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_spec_stat_q;
+  TagType                [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_tag_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_mask_q;
+  AuxType                [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_aux_q;
+  logic                  [0:NUM_MO_EARLY_REGS]                    mo_early_pipe_valid_q;
   // Ready signal is combinatorial for all stages
-  logic [0:NUM_MO_EARLY_REGS]                                       mo_early_pipe_ready;
+  logic [0:NUM_MO_EARLY_REGS]                                     mo_early_pipe_ready;
 
   // Input stage: First element of pipeline is taken from upstream logic
   assign mo_early_pipe_sum_magnitude_q[0] = sum_magnitude;
   assign mo_early_pipe_final_sign_q[0]    = final_sign;
   assign mo_early_pipe_scale_q[0]         = scale_q;
-  assign mo_early_pipe_acc_sticky_q[0]    = accumulator_sticky_q0;
-  assign mo_early_pipe_res_is_acc_q[0]    = result_is_accumulator_q0;
-  assign mo_early_pipe_sop_is_zero_q[0]   = sum_product_is_zero_q0;
+  assign mo_early_pipe_acc_sticky_q[0]    = accumulator_sticky_q;
+  assign mo_early_pipe_res_is_acc_q[0]    = result_is_accumulator_q;
+  assign mo_early_pipe_sop_is_zero_q[0]   = sum_product_is_zero_q;
   assign mo_early_pipe_operand_d_q[0]     = operand_d_q2;
   assign mo_early_pipe_dst_fmt_q[0]       = dst_fmt_q2;
   assign mo_early_pipe_rnd_mode_q[0]      = mid_pipe_rnd_mode_q[NUM_MID_REGS];
@@ -994,11 +994,11 @@ module fpnew_mxdotp_multi
   logic [LZC_SUM_WIDTH-1:0]         sum_magnitude_q2;
   logic signed [LZC_RESULT_WIDTH:0] leading_zero_count_sgn_q;
   logic                             lzc_zeroes_q;
-  logic [DST_EXP_WIDTH-1:0]             scale_q3;
+  logic [DST_EXP_WIDTH-1:0]         scale_q3;
   logic                             final_sign_q;
-  logic                             accumulator_sticky_q;
-  logic                             result_is_accumulator_q;
-  logic                             sop_is_zero_q2;
+  logic                             accumulator_sticky_q2;
+  logic                             result_is_accumulator_q2;
+  logic                             sum_product_is_zero_q2;
   fp_dst_t                          operand_d_q3;
   fpnew_pkg::fp_format_e            dst_fmt_q3;
   fpnew_pkg::roundmode_e            rnd_mode_q;
@@ -1010,46 +1010,46 @@ module fpnew_mxdotp_multi
   fpnew_pkg::status_t               special_status_q;
 
   // MO-late pipeline signals, index i holds signal after i register stages
-  logic                  [0:NUM_MO_LATE_REGS][LZC_SUM_WIDTH-1:0]      mo_late_pipe_sum_magnitude_q;
-  logic signed           [0:NUM_MO_LATE_REGS][LZC_RESULT_WIDTH:0]     mo_late_pipe_lzc_count_sgn_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_lzc_zeroes_q;
-  logic                  [0:NUM_MO_LATE_REGS][DST_EXP_WIDTH-1:0]          mo_late_pipe_scale_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_final_sign_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_acc_sticky_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_res_is_acc_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_sop_is_zero_q;
-  fp_dst_t               [0:NUM_MO_LATE_REGS]                         mo_late_pipe_operand_d_q;
-  fpnew_pkg::fp_format_e [0:NUM_MO_LATE_REGS]                         mo_late_pipe_dst_fmt_q;
-  fpnew_pkg::roundmode_e [0:NUM_MO_LATE_REGS]                         mo_late_pipe_rnd_mode_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_res_is_spec_q;
-  logic                  [0:NUM_MO_LATE_REGS][1:0]          mo_late_pipe_spec_res_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_spec_stat_q;
-  TagType                [0:NUM_MO_LATE_REGS]                         mo_late_pipe_tag_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_mask_q;
-  AuxType                [0:NUM_MO_LATE_REGS]                         mo_late_pipe_aux_q;
-  logic                  [0:NUM_MO_LATE_REGS]                         mo_late_pipe_valid_q;
+  logic                  [0:NUM_MO_LATE_REGS][LZC_SUM_WIDTH-1:0]  mo_late_pipe_sum_magnitude_q;
+  logic signed           [0:NUM_MO_LATE_REGS][LZC_RESULT_WIDTH:0] mo_late_pipe_lzc_count_sgn_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_lzc_zeroes_q;
+  logic                  [0:NUM_MO_LATE_REGS][DST_EXP_WIDTH-1:0]  mo_late_pipe_scale_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_final_sign_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_acc_sticky_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_res_is_acc_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_sop_is_zero_q;
+  fp_dst_t               [0:NUM_MO_LATE_REGS]                     mo_late_pipe_operand_d_q;
+  fpnew_pkg::fp_format_e [0:NUM_MO_LATE_REGS]                     mo_late_pipe_dst_fmt_q;
+  fpnew_pkg::roundmode_e [0:NUM_MO_LATE_REGS]                     mo_late_pipe_rnd_mode_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_res_is_spec_q;
+  logic                  [0:NUM_MO_LATE_REGS][1:0]                mo_late_pipe_spec_res_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_spec_stat_q;
+  TagType                [0:NUM_MO_LATE_REGS]                     mo_late_pipe_tag_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_mask_q;
+  AuxType                [0:NUM_MO_LATE_REGS]                     mo_late_pipe_aux_q;
+  logic                  [0:NUM_MO_LATE_REGS]                     mo_late_pipe_valid_q;
   // Ready signal is combinatorial for all stages
-  logic [0:NUM_MO_LATE_REGS]                                          mo_late_pipe_ready;
+  logic [0:NUM_MO_LATE_REGS]                                      mo_late_pipe_ready;
 
   // Input stage: First element of pipeline is taken from upstream logic
-  assign mo_late_pipe_sum_magnitude_q[0]        = sum_magnitude_q;
-  assign mo_late_pipe_lzc_count_sgn_q[0]        = leading_zero_count_sgn;
-  assign mo_late_pipe_lzc_zeroes_q[0]           = lzc_zeroes;
-  assign mo_late_pipe_scale_q[0]                = scale_q2;
-  assign mo_late_pipe_final_sign_q[0]           = mo_early_pipe_final_sign_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_acc_sticky_q[0]           = mo_early_pipe_acc_sticky_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_res_is_acc_q[0]           = mo_early_pipe_res_is_acc_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_sop_is_zero_q[0]          = mo_early_pipe_sop_is_zero_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_operand_d_q[0]            = mo_early_pipe_operand_d_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_dst_fmt_q[0]              = mo_early_pipe_dst_fmt_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_rnd_mode_q[0]             = mo_early_pipe_rnd_mode_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_res_is_spec_q[0]          = mo_early_pipe_res_is_spec_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_spec_res_q[0]             = mo_early_pipe_spec_res_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_spec_stat_q[0]            = mo_early_pipe_spec_stat_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_tag_q[0]                  = mo_early_pipe_tag_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_mask_q[0]                 = mo_early_pipe_mask_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_aux_q[0]                  = mo_early_pipe_aux_q[NUM_MO_EARLY_REGS];
-  assign mo_late_pipe_valid_q[0]                = mo_early_pipe_valid_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_sum_magnitude_q[0] = sum_magnitude_q;
+  assign mo_late_pipe_lzc_count_sgn_q[0] = leading_zero_count_sgn;
+  assign mo_late_pipe_lzc_zeroes_q[0]    = lzc_zeroes;
+  assign mo_late_pipe_scale_q[0]         = scale_q2;
+  assign mo_late_pipe_final_sign_q[0]    = mo_early_pipe_final_sign_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_acc_sticky_q[0]    = mo_early_pipe_acc_sticky_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_res_is_acc_q[0]    = mo_early_pipe_res_is_acc_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_sop_is_zero_q[0]   = mo_early_pipe_sop_is_zero_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_operand_d_q[0]     = mo_early_pipe_operand_d_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_dst_fmt_q[0]       = mo_early_pipe_dst_fmt_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_rnd_mode_q[0]      = mo_early_pipe_rnd_mode_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_res_is_spec_q[0]   = mo_early_pipe_res_is_spec_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_spec_res_q[0]      = mo_early_pipe_spec_res_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_spec_stat_q[0]     = mo_early_pipe_spec_stat_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_tag_q[0]           = mo_early_pipe_tag_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_mask_q[0]          = mo_early_pipe_mask_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_aux_q[0]           = mo_early_pipe_aux_q[NUM_MO_EARLY_REGS];
+  assign mo_late_pipe_valid_q[0]         = mo_early_pipe_valid_q[NUM_MO_EARLY_REGS];
   // Input stage: Propagate pipeline ready signal to MO-early pipe
   assign mo_early_pipe_ready[NUM_MO_EARLY_REGS] = mo_late_pipe_ready[0];
 
@@ -1085,20 +1085,20 @@ module fpnew_mxdotp_multi
     `FFL(mo_late_pipe_aux_q[i+1],           mo_late_pipe_aux_q[i],           reg_ena, AuxType'('0))
   end
   // Output stage: assign selected pipe outputs to signals for later use
-  assign sum_magnitude_q2          = mo_late_pipe_sum_magnitude_q[NUM_MO_LATE_REGS];
-  assign leading_zero_count_sgn_q  = mo_late_pipe_lzc_count_sgn_q[NUM_MO_LATE_REGS];
-  assign lzc_zeroes_q              = mo_late_pipe_lzc_zeroes_q[NUM_MO_LATE_REGS];
-  assign scale_q3                  = mo_late_pipe_scale_q[NUM_MO_LATE_REGS];
-  assign final_sign_q              = mo_late_pipe_final_sign_q[NUM_MO_LATE_REGS];
-  assign accumulator_sticky_q      = mo_late_pipe_acc_sticky_q[NUM_MO_LATE_REGS];
-  assign result_is_accumulator_q   = mo_late_pipe_res_is_acc_q[NUM_MO_LATE_REGS];
-  assign sop_is_zero_q2            = mo_late_pipe_sop_is_zero_q[NUM_MO_LATE_REGS];
-  assign operand_d_q3              = mo_late_pipe_operand_d_q[NUM_MO_LATE_REGS];
-  assign dst_fmt_q3                = mo_late_pipe_dst_fmt_q[NUM_MO_LATE_REGS];
-  assign rnd_mode_q                = mo_late_pipe_rnd_mode_q[NUM_MO_LATE_REGS];
-  assign result_is_special_raw_q   = mo_late_pipe_res_is_spec_q[NUM_MO_LATE_REGS];
-  assign special_code_q            = mo_late_pipe_spec_res_q[NUM_MO_LATE_REGS];
-  assign special_nv_q              = mo_late_pipe_spec_stat_q[NUM_MO_LATE_REGS];
+  assign sum_magnitude_q2         = mo_late_pipe_sum_magnitude_q[NUM_MO_LATE_REGS];
+  assign leading_zero_count_sgn_q = mo_late_pipe_lzc_count_sgn_q[NUM_MO_LATE_REGS];
+  assign lzc_zeroes_q             = mo_late_pipe_lzc_zeroes_q[NUM_MO_LATE_REGS];
+  assign scale_q3                 = mo_late_pipe_scale_q[NUM_MO_LATE_REGS];
+  assign final_sign_q             = mo_late_pipe_final_sign_q[NUM_MO_LATE_REGS];
+  assign accumulator_sticky_q2    = mo_late_pipe_acc_sticky_q[NUM_MO_LATE_REGS];
+  assign result_is_accumulator_q2 = mo_late_pipe_res_is_acc_q[NUM_MO_LATE_REGS];
+  assign sum_product_is_zero_q2   = mo_late_pipe_sop_is_zero_q[NUM_MO_LATE_REGS];
+  assign operand_d_q3             = mo_late_pipe_operand_d_q[NUM_MO_LATE_REGS];
+  assign dst_fmt_q3               = mo_late_pipe_dst_fmt_q[NUM_MO_LATE_REGS];
+  assign rnd_mode_q               = mo_late_pipe_rnd_mode_q[NUM_MO_LATE_REGS];
+  assign result_is_special_raw_q  = mo_late_pipe_res_is_spec_q[NUM_MO_LATE_REGS];
+  assign special_code_q           = mo_late_pipe_spec_res_q[NUM_MO_LATE_REGS];
+  assign special_nv_q             = mo_late_pipe_spec_stat_q[NUM_MO_LATE_REGS];
 
   // Rebuild the 32-bit special result / status word from the carried verdict.
   fpnew_mxdotp_special_assemble #(
@@ -1117,7 +1117,6 @@ module fpnew_mxdotp_multi
   // -------------------------------------------
   // Normalization 3: Shift + mantissa assembly
   // -------------------------------------------
-  logic [LZC_SUM_WIDTH-1:0]        sum_magnitude_true;
   logic [DST_PRECISION_BITS-1:0]   final_mantissa;
   logic signed [DST_EXP_WIDTH-1:0] final_exponent;
   logic                            sticky_after_norm;
@@ -1130,8 +1129,7 @@ module fpnew_mxdotp_multi
     .lzc_zeroes             ( lzc_zeroes_q             ),
     .exponent_major         ( scale_q3                 ),
     .final_sign             ( final_sign_q             ),
-    .accumulator_sticky     ( accumulator_sticky_q     ),
-    .sum_magnitude_o        ( sum_magnitude_true       ),
+    .accumulator_sticky     ( accumulator_sticky_q2    ),
     .final_mantissa         ( final_mantissa           ),
     .final_exponent         ( final_exponent           ),
     .sticky_after_norm      ( sticky_after_norm        )
@@ -1156,7 +1154,6 @@ module fpnew_mxdotp_multi
     .final_mantissa(final_mantissa),
     .final_exponent(final_exponent),
     .sticky_after_norm(sticky_after_norm),
-    .sum_magnitude(sum_magnitude_true),
     .dst_fmt(dst_fmt_q3),
     .rnd_mode(rnd_mode_q),
     .round_sticky_bits(round_sticky_bits),
@@ -1187,7 +1184,7 @@ module fpnew_mxdotp_multi
   assign accumulator_status.DZ = 1'b0;
   assign accumulator_status.OF = 1'b0;
   assign accumulator_status.UF = 1'b0;
-  assign accumulator_status.NX = ~sop_is_zero_q2;
+  assign accumulator_status.NX = ~sum_product_is_zero_q2;
 
   assign accumulator_result = (dst_fmt_q3 == fpnew_pkg::FP16ALT) ?
                               {16'hFFFF, operand_d_q3[31:16]} :
@@ -1207,7 +1204,7 @@ module fpnew_mxdotp_multi
   logic                 use_regular;
   logic [DST_WIDTH-1:0] early_result;
   fpnew_pkg::status_t   early_status;
-  assign use_regular  = ~result_is_special_q & ~result_is_accumulator_q;
+  assign use_regular  = ~result_is_special_q & ~result_is_accumulator_q2;
   assign early_result = result_is_special_q ? special_result_q : accumulator_result;
   assign early_status = result_is_special_q ? special_status_q : accumulator_status;
 
@@ -1225,15 +1222,15 @@ module fpnew_mxdotp_multi
   AuxType             [0:NUM_OUT_REGS]                out_pipe_aux_q;
   logic               [0:NUM_OUT_REGS]                out_pipe_valid_q;
   // Ready signal is combinatorial for all stages
-  logic [0:NUM_OUT_REGS] out_pipe_ready;
+  logic [0:NUM_OUT_REGS]                              out_pipe_ready;
 
   // Input stage: First element of pipeline is taken from inputs
-  assign out_pipe_result_q[0]                 = result_d;
-  assign out_pipe_status_q[0]                 = status_d;
-  assign out_pipe_tag_q[0]                    = mo_late_pipe_tag_q[NUM_MO_LATE_REGS];
-  assign out_pipe_mask_q[0]                   = mo_late_pipe_mask_q[NUM_MO_LATE_REGS];
-  assign out_pipe_aux_q[0]                    = mo_late_pipe_aux_q[NUM_MO_LATE_REGS];
-  assign out_pipe_valid_q[0]                  = mo_late_pipe_valid_q[NUM_MO_LATE_REGS];
+  assign out_pipe_result_q[0] = result_d;
+  assign out_pipe_status_q[0] = status_d;
+  assign out_pipe_tag_q[0]    = mo_late_pipe_tag_q[NUM_MO_LATE_REGS];
+  assign out_pipe_mask_q[0]   = mo_late_pipe_mask_q[NUM_MO_LATE_REGS];
+  assign out_pipe_aux_q[0]    = mo_late_pipe_aux_q[NUM_MO_LATE_REGS];
+  assign out_pipe_valid_q[0]  = mo_late_pipe_valid_q[NUM_MO_LATE_REGS];
   // Input stage: Propagate pipeline ready signal to MO-late pipe
   assign mo_late_pipe_ready[NUM_MO_LATE_REGS] = out_pipe_ready[0];
   // Generate the register stages
@@ -1258,13 +1255,13 @@ module fpnew_mxdotp_multi
   // Output stage: Ready travels backwards from output side, driven by downstream circuitry
   assign out_pipe_ready[NUM_OUT_REGS] = out_ready_i;
   // Output stage: assign module outputs
-  assign result_o        = out_pipe_result_q[NUM_OUT_REGS];
-  assign status_o        = out_pipe_status_q[NUM_OUT_REGS];
+  assign result_o = out_pipe_result_q[NUM_OUT_REGS];
+  assign status_o = out_pipe_status_q[NUM_OUT_REGS];
   assign extension_bit_o = 1'b1; // always NaN-Box result
-  assign tag_o           = out_pipe_tag_q[NUM_OUT_REGS];
-  assign mask_o          = out_pipe_mask_q[NUM_OUT_REGS];
-  assign aux_o           = out_pipe_aux_q[NUM_OUT_REGS];
-  assign out_valid_o     = out_pipe_valid_q[NUM_OUT_REGS];
+  assign tag_o       = out_pipe_tag_q[NUM_OUT_REGS];
+  assign mask_o      = out_pipe_mask_q[NUM_OUT_REGS];
+  assign aux_o       = out_pipe_aux_q[NUM_OUT_REGS];
+  assign out_valid_o = out_pipe_valid_q[NUM_OUT_REGS];
   assign busy_o          = (| {inp_pipe_valid_q, inp_mid_pipe_valid_q, mid_pipe_valid_q,
                                mo_early_pipe_valid_q, mo_late_pipe_valid_q, out_pipe_valid_q});
 endmodule

--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -1167,10 +1167,15 @@ module fpnew_mxdotp_norm_window
   localparam int unsigned W2 = DST_PRECISION_BITS + 31;           //  55
   localparam int unsigned W3 = DST_PRECISION_BITS + 15;           //  39
 
-  // Only shift amounts >= 2**7 need explicit forcing: for 119 <= p <= 127 the
-  // window indices (118-p .. 95-p) are already all negative and the sticky
-  // range X[94-p:0] is already empty, so the chain returns the same zero
-  // by itself.  Catching only p >= 128 makes this one OR of two bits and lets
+  if (W0 <= 64 || W0 > 128) begin
+    $fatal(1, "fpnew_mxdotp_norm_window: LZC_SUM_WIDTH=%0d outside the supported (64,128] range", W0);
+  end
+
+  // Only shift amounts >= 2**7 need explicit forcing: for W0 <= p <= 127 the
+  // window indices (W0-1-p .. W0-24-p) are already all negative and the sticky
+  // range X[W0-25-p:0] is already empty, so the chain returns the same zero
+  // by itself (requires 64 < W0 <= 128, which holds for VectorSize <= 4096).
+  // Catching only p >= 128 makes this one OR of two bits and lets
   // the forcing sit at the FIRST stage instead of on the outputs at the end.
   logic shift_out_all;
   assign shift_out_all = (| norm_shamt[SHIFT_AMOUNT_WIDTH-1:7]);
@@ -1178,8 +1183,15 @@ module fpnew_mxdotp_norm_window
   logic [W1-1:0] v1; logic [W2-1:0] v2; logic [W3-1:0] v3;
   logic s1, s2, s3, s4, s5, s6, s7;
 
+  // Stage 1 (shift by 64): the top W1 bits of (X << 64).  Written as a
+  // constant shift so the window stays correct for every LZC_SUM_WIDTH
+  // (119 at VectorSize=8, 121 at VectorSize=32, ...); a hand-built
+  // {X[W0-65:0], 32'b0} is only right for W0 == 119.
+  logic [W0-1:0] sum_magnitude_shl64;
+  assign sum_magnitude_shl64 = sum_magnitude << 64;
+
   assign v1 = shift_out_all ? '0
-                            : (norm_shamt[6] ? {sum_magnitude[W0-1-64:0], 32'b0}
+                            : (norm_shamt[6] ? sum_magnitude_shl64[W0-1 -: W1]
                                              : sum_magnitude[W0-1 -: W1]);
   assign s1 = (shift_out_all | norm_shamt[6]) ? 1'b0 : |sum_magnitude[W0-W1-1:0];
   assign v2 = norm_shamt[5] ? v1[W2-1:0] : v1[W1-1 -: W2];

--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -587,73 +587,7 @@ module fpnew_mxdotp_signed_vector_multiplier
   end
 endmodule
 
-// Shifts products left by (exp_a + exp_b - 2×bias + SOP_SHIFT) to align to fixed-point anchor.
-// Handles FP8/FP6/FP4 with format-specific offsets; INT8 shifts directly to anchor position.
-module fpnew_mxdotp_product_shifter
-  import fpnew_mxdotp_multi_pkg::*;
-#(
-  parameter type         SrcType          = logic,
-  parameter int unsigned LocalVectorSize  = 8,
-  parameter fpnew_pkg::fp_format_e SrcFmt = fpnew_pkg::FP8,
-  parameter int unsigned ProductBits      = 4,
-  parameter int unsigned ExpWidth         = 8,
-  parameter int unsigned OutputWidth      = 70
-) (
-  // Input signals
-  input  SrcType [LocalVectorSize-1:0] operands_a,
-  input  SrcType [LocalVectorSize-1:0] operands_b,
-  input  logic [LocalVectorSize-1:0][ProductBits-1:0] product_signed,
-  input  fpnew_pkg::fp_info_t [LocalVectorSize-1:0] info_a,
-  input  fpnew_pkg::fp_info_t [LocalVectorSize-1:0] info_b,
-  input  fpnew_pkg::fp_format_e src_fmt,
-  input  fpnew_pkg::int_format_e int_fmt,
-  input  logic src_is_int,
-  output logic signed [LocalVectorSize-1:0][OutputWidth-1:0] shifted_product
-);
-  // ------------------
-  // Shift data path
-  // ------------------
-  logic signed [LocalVectorSize-1:0][ExpWidth-1:0] exponent_product;
-
-  // Calculate the non-biased exponent of the product
-  for (genvar i = 0; i < LocalVectorSize; i++) begin : gen_exponent_adjustment
-    assign exponent_product[i] = operands_a[i].exponent + info_a[i].is_subnormal
-                                + operands_b[i].exponent + info_b[i].is_subnormal
-                                - 2*signed'(bias_constant(src_fmt));
-    if (SrcFmt == fpnew_pkg::FP8) begin
-      always_comb begin // TODO: Generate only for INT8 vs FP8
-        if (src_is_int && int_fmt == fpnew_pkg::INT8) begin
-          // INT8: shift to integer position
-          shifted_product[i] = signed'(product_signed[i]) << ANCHOR;
-        end else begin
-          // Right shift the significand by anchor point - exponent
-          // sum of four 9-bit numbers can be at most 11 bits, for 69 bits output we need to shift by 69 - 11 = 58
-          // 58-30=28 plus inherit 6 fractional bits from the multiplication -> point moves to 28+6=34
-          // max shift can be 58 (28 + exp-max(30)), min shift is 0 (28 + exp-min(-28))
-          //
-          // In the FP8/FP8ALT branch both mantissae are 4-bit magnitudes
-          // (implicit bit + 3 mantissa bits), so the product lies in
-          // [-16*15, 15*15] = [-240,225] and product_signed[ProductBits-1:9]
-          // is pure sign extension of bit 8.  Only those 9 bits therefore
-          // have to enter the variable shifter -- the sign extension is
-          // re-created for free by the signed widening of the assignment.
-          // (Only the INT8 branch, whose shift amount is the CONSTANT
-          // ANCHOR and hence pure wiring, needs the full product width.)
-          shifted_product[i] = signed'(product_signed[i][2*PRECISION_BITS:0]) << (signed'(SOP_SHIFT) + signed'(exponent_product[i]));
-        end
-      end
-    end else if (SrcFmt == fpnew_pkg::FP6) begin
-      // E3 exponent_product is in range [-4, 8], requires 5b for signed representation
-      // To make shift positive, we scale by 4
-      assign shifted_product[i] = signed'(product_signed[i]) << (signed'(4) + signed'(exponent_product[i]));
-    end else begin
-      // exponent_product is negative only for zero inputs for FP4
-      assign shifted_product[i] = signed'(product_signed[i]) << exponent_product[i];
-    end
-  end
-endmodule
-
-// Early half of fpnew_mxdotp_product_shifter: the per-lane product exponent.
+// Early half of the former fpnew_mxdotp_product_shifter: the per-lane product exponent.
 // Depends only on the (classified) operands, never on the product, so it can sit
 // in a different pipeline stage than the alignment shift below.
 module fpnew_mxdotp_product_exponent
@@ -752,57 +686,6 @@ module fpnew_mxdotp_product_align
       assign shifted_product[i] = signed'(product_signed[i]) << shift_amount[i];
     end
   end
-endmodule
-
-// Sums all shifted products in the vector.
-module fpnew_mxdotp_adder_tree
-  import fpnew_mxdotp_multi_pkg::*;
-#(
-  parameter int unsigned LocalVectorSize = 8,
-  parameter int unsigned InputWidth      = 4,
-  parameter int unsigned OutputWidth     = 70
-) (
-  // Input signals
-  input  logic signed [LocalVectorSize-1:0][InputWidth-1:0] shifted_product,
-  output logic signed [OutputWidth-1:0] sum_product
-);
-  // ------------------
-  // Adder data path
-  // ------------------
-  // Sum the products
-  always_comb begin : sum_products
-    sum_product = '0;
-    for (int i = 0; i < LocalVectorSize; i++) begin : gen_sum_products
-      sum_product += signed'(shifted_product[i]);
-    end
-  end
-endmodule
-
-// Adds FP8, FP6, and FP4 sum-of-products; shifts FP6 and FP4 sums to align before adding.
-// When FP6 is disabled, sum_product_fp6 is zero and optimized away by synthesis.
-module fpnew_mxdotp_format_adder
-  import fpnew_mxdotp_multi_pkg::*;
-#(
-  parameter int unsigned Fp6SumWidth = FP6_PROD_SHIFT_WIDTH,
-  parameter int unsigned Fp4SumWidth = FP4_PROD_SHIFT_WIDTH,
-  parameter int unsigned SoPFixedWidth = 70,
-  // Do not change the following parameters
-  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1) // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
-) (
-  input  logic signed [SoPFixedWidth-1:0] sum_product_fp8,
-  input  logic signed [Fp6SumWidth-1:0]     sum_product_fp6,
-  input  logic signed [Fp4SumWidth-1:0]     sum_product_fp4,
-  output logic signed [FIXED_SUM_WIDTH-1:0] sum_product
-);
-  // ------------------
-  // Adder data path
-  // ------------------
-  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_fp4_shifted;
-  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_fp6_shifted;
-
-  assign sum_product_fp4_shifted = signed'(sum_product_fp4) << (SOP_SHIFT+2*(SUPER_MAN_BITS-FP4_MAN_BITS));
-  assign sum_product_fp6_shifted = signed'(sum_product_fp6) << (SOP_SHIFT-4+2*(SUPER_MAN_BITS-FP6_MAN_BITS)); // 4 is subtracted to account for the 4-bit shift in the product shifter
-  assign sum_product = sum_product_fp8 + sum_product_fp4_shifted + sum_product_fp6_shifted;
 endmodule
 
 // Shifts accumulator right to align with sum-of-products based on scale and accumulator exponent.
@@ -916,28 +799,6 @@ module fpnew_mxdotp_accumulator_shift
       end
     end
   end
-endmodule
-
-// Adds aligned accumulator to sum-of-products, extending with accumulator remainder bits.
-module fpnew_mxdotp_add_accumulator_sop
-  import fpnew_mxdotp_multi_pkg::*;
-#(
-  parameter int unsigned SoPFixedWidth = 70,
-  // Do not change the following parameters
-  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
-  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS
-) (
-  // Input signals
-  input  logic signed [FIXED_SUM_WIDTH-1:0] sum_product,
-  input  logic signed [FIXED_SUM_WIDTH-1:0] accumulator_shifted,
-  input  logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining,
-  output logic signed [LZC_SUM_WIDTH-1:0] sum_product_accumulator_extended
-);
-
-  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_accumulator;
-
-  assign sum_product_accumulator = sum_product + accumulator_shifted;
-  assign sum_product_accumulator_extended = {sum_product_accumulator, accumulator_remaining};
 endmodule
 
 
@@ -1075,31 +936,6 @@ module fpnew_mxdotp_twos_compl
   // ------------------------------------------------------------------
   assign sum_magnitude = sum_product_accumulator_extended
                        ^ {LZC_SUM_WIDTH{final_sign}};
-endmodule
-
-// Shifts magnitude left by normalization amount to align leading 1 to implicit bit position.
-module fpnew_mxdotp_norm_shift
-  import fpnew_mxdotp_multi_pkg::*;
-#(
-  parameter int unsigned SoPFixedWidth = 70,
-  // Do not change the following parameters
-  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
-  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS,
-  // Shift amount width: $clog2(DST_BIAS - ANCHOR + (scale_a+scale_b) + FIXED_SUM_WIDTH - 1)
-  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(fpnew_pkg::bias(fpnew_pkg::FP32) - ANCHOR + 2**(SCALE_WIDTH) - 1 + FIXED_SUM_WIDTH - 1)
-) (
-  // Input signals
-  input  logic [LZC_SUM_WIDTH-1:0] sum_magnitude,
-  input  logic [SHIFT_AMOUNT_WIDTH-1:0] norm_shamt,
-  // Output signals
-  output logic [LZC_SUM_WIDTH-1:0] sum_shifted
-);
-  // ------------------
-  // Normalization shift
-  // ------------------
-
-  // Shift the sum to normalize it
-  assign sum_shifted = sum_magnitude << norm_shamt;
 endmodule
 
 // Normalisation window extractor with fused sticky collection.

--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -757,11 +757,11 @@ module fpnew_mxdotp_accumulator_shift
   // {signed_mantissa_d, 24'b0} >>> accumulator_right_shift_amount_w, 49 bits.
   // The shift amount is taken from a wire (not from the always_comb output) so
   // that the funnel stays outside the procedural block.
-  logic signed [9:0] accumulator_right_shift_amount_w;
+  logic signed [9:0] accumulator_right_shift_amount;
   logic signed [2*DST_PRECISION_BITS:0] accumulator_funnel;
-  assign accumulator_right_shift_amount_w = -accumulator_shift_amount;
+  assign accumulator_right_shift_amount = -accumulator_shift_amount;
   assign accumulator_funnel = signed'({signed_mantissa_d, {DST_PRECISION_BITS{1'b0}}})
-                              >>> accumulator_right_shift_amount_w;
+                              >>> accumulator_right_shift_amount;
 
   always_comb begin : accumulator_shift
     result_is_accumulator_uncond = 1'b0;
@@ -791,9 +791,9 @@ module fpnew_mxdotp_accumulator_shift
       //           49-bit container's MSB, which IS m's sign bit.
       // One shifter instead of two; identical bits in both branches.
       accumulator_remaining = accumulator_funnel[DST_PRECISION_BITS-1:0];
-      if (accumulator_right_shift_amount_w > DST_PRECISION_BITS) begin
+      if (accumulator_right_shift_amount > DST_PRECISION_BITS) begin
         result_is_accumulator_if_sop_zero = 1'b1;
-        accumulator_sticky = |(signed'(signed_mantissa_d) & ((1 << (accumulator_right_shift_amount_w - DST_PRECISION_BITS)) - 1));
+        accumulator_sticky = |(signed'(signed_mantissa_d) & ((1 << (accumulator_right_shift_amount - DST_PRECISION_BITS)) - 1));
       end else begin
         accumulator_sticky = 1'b0;
       end
@@ -835,7 +835,7 @@ module fpnew_mxdotp_fused_sop_accumulator
   output logic                                 sum_product_is_zero,
   output logic signed [LZC_SUM_WIDTH-1:0]      sum_product_accumulator_extended
 );
-  logic signed [SoPFixedWidth-1:0] sum_product_fp8;
+  logic signed [SoPFixedWidth-1:0]   sum_product_fp8;
   logic signed [Fp6SumWidth-1:0]     sum_product_fp6;
   logic signed [Fp4SumWidth-1:0]     sum_product_fp4;
   logic signed [FIXED_SUM_WIDTH-1:0] sum_product_fp4_shifted;
@@ -998,13 +998,15 @@ module fpnew_mxdotp_norm_window
   // The original stages 4..7 are four multiplexer levels on the LATEST signal
   // in the design (the shift amount comes straight out of the leading-zero
   // count); a single 16-way select is one decoder plus one AND-OR level.
-  localparam int unsigned W0 = LZC_SUM_WIDTH;                     // 119
-  localparam int unsigned W1 = DST_PRECISION_BITS + 63;           //  87
-  localparam int unsigned W2 = DST_PRECISION_BITS + 31;           //  55
-  localparam int unsigned W3 = DST_PRECISION_BITS + 15;           //  39
+  localparam int unsigned W0 = LZC_SUM_WIDTH;
+  localparam int unsigned W1 = DST_PRECISION_BITS + 63;
+  localparam int unsigned W2 = DST_PRECISION_BITS + 31;
+  localparam int unsigned W3 = DST_PRECISION_BITS + 15;
 
-  if (W0 <= 64 || W0 > 128) begin
-    $fatal(1, "fpnew_mxdotp_norm_window: LZC_SUM_WIDTH=%0d outside the supported (64,128] range", W0);
+  // W0 >= W1 keeps the first stage's part-selects in range; W0 <= 128 keeps norm_shamt[6:0]
+  // sufficient to distinguish every shift that does not clear the window outright.
+  if (W0 < W1 || W0 > 128) begin
+    $fatal(1, "fpnew_mxdotp_norm_window: LZC_SUM_WIDTH=%0d outside the supported [%0d,128] range", W0, W1);
   end
 
   // Only shift amounts >= 2**7 need explicit forcing: for W0 <= p <= 127 the
@@ -1016,7 +1018,9 @@ module fpnew_mxdotp_norm_window
   logic shift_out_all;
   assign shift_out_all = (| norm_shamt[SHIFT_AMOUNT_WIDTH-1:7]);
 
-  logic [W1-1:0] v1; logic [W2-1:0] v2; logic [W3-1:0] v3;
+  logic [W1-1:0] v1;
+  logic [W2-1:0] v2;
+  logic [W3-1:0] v3;
   logic s1, s2, s3, s4, s5, s6, s7;
 
   // Stage 1 (shift by 64): the top W1 bits of (X << 64).  Written as a
@@ -1075,37 +1079,27 @@ module fpnew_mxdotp_norm_window
   assign sticky_bits_or = s1 | s2 | s3 | s4 | s5 | s6 | s7;
 endmodule
 
-// Computes normalization shift amount and biased exponent from sign-magnitude sum via leading-zero
-// count. Handles subnormals (normalized_exponent = 0) and zero (lzc_zeroes path).
-
-// Leading-zero counter for the normalisation path (drop-in for common_cells
-// `lzc #(.WIDTH(119), .MODE(1))`, bit-identical on EVERY input including the
-// all-zero one, where both return cnt_o = 0).
-//
-// common_cells builds a BINARY reduction tree in which the index has to travel
-// through $clog2(WIDTH)=7 multiplexers whose selects are themselves OR trees;
-// which is deep, and it is the largest single block of the pre-normalisation
-// stage.  The tree below is RADIX-4: 128 padded
-// bits -> 32 -> 8 -> 2 -> 1, so the index crosses three 4:1 selects and one
-// 2:1 select while the `any` OR tree that drives those selects is only three
-// OR4 levels deep.  Each node emits the position of its FIRST set input, or
-// zero when it has none, which is what makes the all-zero result 0 without a
-// masking gate on the output.
-module fpnew_mxdotp_lzc119 #(
-  parameter int unsigned WIDTH     = 119,
-  parameter int unsigned CNT_WIDTH = 7
+module fpnew_mxdotp_lzc #(
+  parameter int unsigned Width    = 119,
+  // Do not change the following parameter
+  localparam int unsigned CntWidth = $clog2(Width)
 ) (
-  input  logic [WIDTH-1:0]     in_i,
-  output logic [CNT_WIDTH-1:0] cnt_o,
-  output logic                 empty_o
+  input  logic [Width-1:0]    in_i,
+  output logic [CntWidth-1:0] cnt_o,
+  output logic                empty_o
 );
-  localparam int unsigned PAD = 2**CNT_WIDTH;   // 128
+  localparam int unsigned PAD = 2**CntWidth;
+
+  // The four levels below are hard-wired for a 2**7-entry tree
+  if (CntWidth != 7) begin
+    $fatal(1, "fpnew_mxdotp_lzc: only $clog2(Width) == 7 is implemented, got Width=%0d", Width);
+  end
 
   // Flip so index 0 is the MSB of in_i (leading-zero mode), zero-pad to 4**k.
   logic [PAD-1:0] f;
   for (genvar i = 0; i < PAD; i++) begin : gen_flip
-    if (i < WIDTH) begin : g_real
-      assign f[i] = in_i[WIDTH-1-i];
+    if (i < Width) begin : g_real
+      assign f[i] = in_i[Width-1-i];
     end else begin : g_pad
       assign f[i] = 1'b0;
     end
@@ -1193,9 +1187,8 @@ module fpnew_mxdotp_norm_lzc
   // would need x == 0, which forces final_sign = 0 and hence mag_inc = 0).
   assign lzc_in = sum_magnitude_ones | {{(LZC_SUM_WIDTH-1){1'b0}}, mag_inc};
 
-  fpnew_mxdotp_lzc119 #(
-    .WIDTH     ( LZC_SUM_WIDTH    ),
-    .CNT_WIDTH ( LZC_RESULT_WIDTH ) // radix-4 drop-in, see above
+  fpnew_mxdotp_lzc #(
+    .Width ( LZC_SUM_WIDTH )
   ) i_lzc (
     .in_i    ( lzc_in             ),
     .cnt_o   ( leading_zero_count ),
@@ -1229,9 +1222,6 @@ module fpnew_mxdotp_norm_finalize
   input  logic signed [DST_EXP_WIDTH-1:0]   exponent_major,
   input  logic                              final_sign,
   input  logic                              accumulator_sticky,
-  // Re-materialised true magnitude, so that every consumer of the original
-  // `sum_magnitude` still sees the original value (the rounder port).
-  output logic [LZC_SUM_WIDTH-1:0]          sum_magnitude_o,
   output logic [DST_PRECISION_BITS-1:0]     final_mantissa,
   output logic signed [DST_EXP_WIDTH-1:0]   final_exponent,
   output logic                              sticky_after_norm
@@ -1330,7 +1320,6 @@ module fpnew_mxdotp_norm_finalize
     .sticky_bits_or( sticky_bits_or )
   );
 
-  assign sum_magnitude_o                   = sum_magnitude;
   assign final_exponent                    = normalized_exponent;
   assign sticky_after_norm                 = sticky_bits_or | accumulator_sticky;
 endmodule
@@ -1352,7 +1341,6 @@ module fpnew_mxdotp_rounder
   input  logic final_sign,
   input  logic [DST_EXP_WIDTH-1:0] final_exponent,
   input  logic [DST_PRECISION_BITS-1:0] final_mantissa,
-  input  logic [LZC_SUM_WIDTH-1:0] sum_magnitude,
   input  logic sticky_after_norm,
   input fpnew_pkg::fp_format_e dst_fmt,
   input fpnew_pkg::roundmode_e rnd_mode,

--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -462,7 +462,8 @@ module fpnew_mxdotp_special_assemble
   assign special_result    = fmt_special_result[dst_fmt];
 endmodule
 
-// Adds two signed 8-bit scale values to produce a 9-bit combined scale.
+// Adds the two signed 8-bit scale values and folds in the constant part of the result
+// exponent, producing the LZC-independent term `exponent_major`.
 module fpnew_mxdotp_scale_adder
   import fpnew_mxdotp_multi_pkg::*;
 #(
@@ -688,16 +689,9 @@ module fpnew_mxdotp_product_align
   end
 endmodule
 
-// Shifts accumulator right to align with sum-of-products based on scale and accumulator exponent.
-// Computes shift amount, handles sticky bits, and detects if accumulator dominates the result.
-// Early half of fpnew_mxdotp_accumulator_shift (STAGE 1): everything that
-// depends only on the classified accumulator operand, the scale and the
-// destination format -- i.e. the 24-bit conditional negate that builds
-// signed_mantissa_d and the four-term shift-amount sum.  Both sat in FRONT of
-// the 95-bit accumulator barrel shifter in stage 2; the accumulator lane of
-// stage 1 was empty (only the 9-bit scale adder), so they move into slack.
-// The INP-MID bank stops carrying info_d (8 b, this was its only consumer) and
-// carries the 25-bit signed mantissa and the 10-bit shift amount instead.
+// Computes the accumulator shift amount and signed mantissa for fpnew_mxdotp_accumulator_shift.
+// Depends only on the classified accumulator operand, the scale and the destination format, so it
+// can sit in an earlier pipeline stage than the accumulator barrel shifter.
 module fpnew_mxdotp_accumulator_prep
   import fpnew_mxdotp_multi_pkg::*;
 #(
@@ -733,6 +727,8 @@ module fpnew_mxdotp_accumulator_prep
                                      - signed'(bias_constant(dst_fmt));
 endmodule
 
+// Shifts accumulator right to align with sum-of-products, using the amount from
+// fpnew_mxdotp_accumulator_prep. Handles sticky bits and detects if accumulator dominates.
 module fpnew_mxdotp_accumulator_shift
   import fpnew_mxdotp_multi_pkg::*;
 #(
@@ -940,38 +936,18 @@ endmodule
 
 // Normalisation window extractor with fused sticky collection.
 //
-// The original design left-shifted the full LZC_SUM_WIDTH (=119) bit magnitude by
-// `norm_shamt` and then used only
-//     final_mantissa  = sum_shifted[118:95]      (the top DST_PRECISION_BITS)
-//     sticky_bits_or  = |sum_shifted[94:0]
-// i.e. it paid for a full 119-bit barrel shifter *and* a 95-bit OR tree.
+// Of sum_magnitude shifted left by `norm_shamt` in an LZC_SUM_WIDTH-bit container, only the top
+// DST_PRECISION_BITS reach an output and everything below feeds one sticky OR. So the shift is
+// applied coarse to fine while narrowing the surviving word to the bits that can still land in
+// the window, and the bits each stage drops are exactly the ones the sticky OR consumes.
 //
-// Algebraically, for X = sum_magnitude:
-//     final_mantissa = X[118-shamt : 95-shamt]   (bits below index 0 read as 0)
-//     sticky_bits_or = |X[94-shamt : 0]
-// so only a 24-bit *window* of X has to be routed to the output.  This module
-// therefore shifts coarse-to-fine and NARROWS the surviving word at every
-// stage, keeping only the bits that can still reach the 24-bit window:
-//     119 -> 87 -> 55 -> 39 -> 31 -> 27 -> 25 -> 24
-// which is 288 2:1 muxes instead of 7*119 = 833.
-//
-// The bits a stage drops off the bottom of the window are exactly the bits that
-// have fallen below index 95 of the shifted result, i.e. exactly the bits the
-// original 95-bit OR tree consumed.  So the sticky OR is collected *inside* the
-// narrowing (one small OR per stage, total 32+32+16+8+4+2+1 = 95 terms - the
-// same 95 bits, but ORed at seven shallow points instead of one deep tree).
-// In the d=2^k branch of a stage nothing is dropped, because the bits leaving
-// the bottom of the window there are the zeros shifted in from below.
-//
-// Invariant maintained across the pipeline of stages: `v` (W bits) equals
-// (X << p)[118 : 119-W], and `sticky` is the OR of all bits of (X << p) below
-// index 119-W.  Stage with shift d maps
-//     v' = v[W-1-d : W-W'-d]      (missing low indices are zeros)
+// Invariant, with p the shift applied so far: a stage output `v` of width W equals
+// (X << p)[W0-1 : W0-W], and `sticky` is the OR of all bits of (X << p) below index W0-W.
+// A stage with shift d maps
+//     v'      = d ? v[W-1-d : W-W'-d] : v[W-1 : W-W']   (missing low indices read as zeros)
 //     sticky' = sticky | (d ? 1'b0 : |v[W-W'-1 : 0])
-// Shift amounts >= LZC_SUM_WIDTH shift everything out in the original code (the shift
-// is evaluated in a 119-bit container), so they are detected up front and force
-// window and sticky to zero, which is what lets the seven low shift bits drive
-// the stages.
+// Shift amounts of W0 or more clear window and sticky through the chain itself; only amounts of
+// 2**7 or more need explicit forcing, done once at the first stage.
 module fpnew_mxdotp_norm_window
   import fpnew_mxdotp_multi_pkg::*;
 #(
@@ -1079,6 +1055,10 @@ module fpnew_mxdotp_norm_window
   assign sticky_bits_or = s1 | s2 | s3 | s4 | s5 | s6 | s7;
 endmodule
 
+// Radix-4 leading-zero counter for the normalisation path.
+// NOT a drop-in for cc_lzc: the two agree on every non-zero input, but on the all-zero input
+// cc_lzc returns Width-1 while this returns 0. Both assert empty_o and every consumer here
+// gates on it, so it is not observable in this datapath.
 module fpnew_mxdotp_lzc #(
   parameter int unsigned Width    = 119,
   // Do not change the following parameter
@@ -1156,6 +1136,8 @@ module fpnew_mxdotp_lzc #(
   assign cnt_o   = {sel_d, (sel_d ? code_c[1] : code_c[0])};
 endmodule
 
+// Counts the leading zeros of the magnitude for the normalisation shift. Takes the one's
+// complement plus the pending increment, so the count does not wait for an incrementer.
 module fpnew_mxdotp_norm_lzc
   import fpnew_mxdotp_multi_pkg::*;
 #(
@@ -1294,12 +1276,10 @@ module fpnew_mxdotp_norm_finalize
   // Normalization shift amount based on exponents and LZC (unsigned as only left shifts)
   always_comb begin : norm_shift_amount
     if (tentative_exponent_positive && !lzc_zeroes) begin
-      // true_lzc + 1 == leading_zero_count_sgn - lzc_dec + 1, but the -lzc_dec
-      // is INVISIBLE to fpnew_mxdotp_norm_window: lzc_dec implies the true
-      // magnitude is 2**(LZC_SUM_WIDTH-1-leading_zero_count_sgn+1), so both
-      // shift amounts push the single set bit out of the LZC_SUM_WIDTH-bit
-      // container and the window and its sticky are zero either way.  Only the
-      // exponent keeps the correction (exponent_major_corr above).
+      // NOTE: this is true_lzc + 1 + lzc_dec, one MORE than the corrected count when lzc_dec
+      // is set. Deliberate: lzc_dec implies the magnitude is a power of two, whose single set
+      // bit leaves the container under either amount, so the window and its sticky are zero
+      // either way. Only the exponent keeps the correction (exponent_major_corr above).
       norm_shamt          = leading_zero_count_sgn + 1;
       normalized_exponent = final_tentative_exponent;
     end else begin
@@ -1443,10 +1423,11 @@ module fpnew_mxdotp_rounder
   assign round_sticky_bits  = fmt_round_sticky_bits[dst_fmt];
   assign pre_round_sign     = final_sign;
 
-  // Bit-identical copy of fpnew_rounding's `rounding_decision` always_comb
-  // (EnableRSR = 0 as instantiated below, so RSR is the DONT_CARE branch).
-  // It reads exactly the signals that block reads, so round_up_pre is the
-  // same function of the same inputs as the round_up inside the instance.
+  // WARNING: copy of fpnew_rounding's `rounding_decision` always_comb (EnableRSR = 0 as
+  // instantiated below, so RSR is the DONT_CARE branch). It reads the same signals, so
+  // round_up_pre is the same function as the round_up inside the instance -- but nothing
+  // enforces that, and fpnew_rounding is shared with FMA/SDOTP/CAST/PACE. Any change to its
+  // rounding decision MUST be mirrored here.
   always_comb begin : rounding_decision_replica
     unique case (rnd_mode)
       fpnew_pkg::RNE:

--- a/src/mxdotp/fpnew_mxdotp_multi_modules.sv
+++ b/src/mxdotp/fpnew_mxdotp_multi_modules.sv
@@ -29,6 +29,10 @@ module fpnew_mxdotp_classifier
 ) (
   // Input signals
   input logic [2*VectorSize-1:0][SRC_WIDTH-1:0] operands_post_inp_pipe,
+  // Per-format packing views (see fpnew_mxdotp_multi): the classifier bank
+  // reads these instead of the src_fmt-muxed array.
+  input logic [2*VectorSize-1:0][SRC_WIDTH-1:0] operands_default_view,
+  input logic [2*VectorSize-1:0][SRC_WIDTH-1:0] operands_fp6_view,
   input logic [2*FP6VectorSize-1:0][SRC_WIDTH-1:0] fp6_operands_post_inp_pipe,
   input logic [2*FP4VectorSize-1:0][SRC_WIDTH-1:0] fp4_operands_post_inp_pipe,
   input logic signed [1:0][SCALE_WIDTH-1:0] operands_c_in,
@@ -88,7 +92,17 @@ module fpnew_mxdotp_classifier
     localparam int unsigned MAN_BITS = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
 
     if (FpSrcFmtConfig[fmt]) begin : active_src_format
-      logic [2*VectorSize-1:0][FP_WIDTH-1:0] trimmed_ops;
+      logic [2*VectorSize-1:0][FP_WIDTH-1:0]  trimmed_ops;
+      logic [2*VectorSize-1:0][SRC_WIDTH-1:0] sel_ops;
+
+      // ELABORATION-TIME choice, not a multiplexer: this classifier's result
+      // is only ever consumed through `[src_fmt]` below, so it may be wired
+      // to the packing that holds when src_fmt == fmt.
+      if ((fmt == int'(fpnew_pkg::FP6)) || (fmt == int'(fpnew_pkg::FP6ALT))) begin : gen_fp6_pack
+        assign sel_ops = operands_fp6_view;
+      end else begin : gen_default_pack
+        assign sel_ops = operands_default_view;
+      end
 
       // Classify input
       fpnew_classifier #(
@@ -101,10 +115,10 @@ module fpnew_mxdotp_classifier
         .info_o      ( info_q[fmt][2*VectorSize-1:0]                        )
       );
       for (genvar op = 0; op < 2*VectorSize; op++) begin : gen_operands
-        assign trimmed_ops[op]       = operands_post_inp_pipe[op][FP_WIDTH-1:0];
-        assign fmt_sign[fmt][op]     = operands_post_inp_pipe[op][FP_WIDTH-1];
-        assign fmt_exponent[fmt][op] = signed'({1'b0, operands_post_inp_pipe[op][MAN_BITS+:EXP_BITS]});
-        assign fmt_mantissa[fmt][op] = operands_post_inp_pipe[op][MAN_BITS-1:0] <<
+        assign trimmed_ops[op]       = sel_ops[op][FP_WIDTH-1:0];
+        assign fmt_sign[fmt][op]     = sel_ops[op][FP_WIDTH-1];
+        assign fmt_exponent[fmt][op] = signed'({1'b0, sel_ops[op][MAN_BITS+:EXP_BITS]});
+        assign fmt_mantissa[fmt][op] = sel_ops[op][MAN_BITS-1:0] <<
                                        (SUPER_MAN_BITS - MAN_BITS); // move to left of mantissa
       end
     end else begin : inactive_src_format
@@ -296,8 +310,7 @@ endmodule
 module fpnew_mxdotp_special_cases
   import fpnew_mxdotp_multi_pkg::*;
 #(
-  parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig,
-  parameter int unsigned           VectorSize     = 8
+  parameter int unsigned VectorSize = 8
 ) (
   // Input signals
   input  fp_src_t [VectorSize-1:0]             operands_a,
@@ -308,11 +321,13 @@ module fpnew_mxdotp_special_cases
   input  fpnew_pkg::fp_info_t [VectorSize-1:0] info_b,
   input  fpnew_pkg::fp_info_t [1:0]            info_c,
   input  fpnew_pkg::fp_info_t                  info_d,
-  input  fpnew_pkg::fp_format_e                dst_fmt,
-  // Output signals: special_result, special_status, result_is_special
-  output logic [DST_WIDTH-1:0]                 special_result,
-  output fpnew_pkg::status_t                   special_status,
-  output logic                                 result_is_special
+  // Output signals: the 4-bit special-case verdict (format independent).
+  // fpnew_mxdotp_special_assemble turns it back into the 32-bit result and
+  // the status word at the very end of the pipeline.
+  output logic                                 result_is_special_raw,
+  output logic                                 special_nv,
+  output logic                                 special_is_inf,
+  output logic                                 special_inf_sign
 );
 
   // ---------------------
@@ -368,14 +383,52 @@ module fpnew_mxdotp_special_cases
   assign any_neg_inf = |neg_inf_conditions || (info_d.is_inf && operand_d.sign);
 
   // ----------------------
-  // Special case handling
+  // Special case verdict (format independent -- the three branches of the
+  // original per-format always_comb, transcribed one for one)
   // ----------------------
+  //   if (any_produced_nan)      -> special, NV=1,             result = qNaN
+  //   else if (any_operand_nan)  -> special, NV=signalling_nan, result = qNaN
+  //   else if (any_operand_inf)  -> special,
+  //        pos & neg  -> NV=1,  result = qNaN
+  //        pos        ->        result = +inf
+  //        neg        ->        result = -inf
+  //   else                       -> not special (result/status unused)
+  assign result_is_special_raw = any_produced_nan | any_operand_nan | any_operand_inf;
+  assign special_nv            = any_produced_nan ? 1'b1
+                               : any_operand_nan  ? signalling_nan
+                               : any_operand_inf  ? (any_pos_inf & any_neg_inf)
+                               :                    1'b0;
+  assign special_is_inf        = ~any_produced_nan & ~any_operand_nan & any_operand_inf
+                               & ~(any_pos_inf & any_neg_inf) & (any_pos_inf | any_neg_inf);
+  assign special_inf_sign      = ~any_pos_inf;
+endmodule
+
+// Rebuilds the 32-bit special result and the status word from the 4-bit verdict
+// carried through the pipeline.  This is the former per-format assembly block
+// of fpnew_mxdotp_special_cases, verbatim, with `special_res` driven by the two
+// encoded bits instead of by the condition chain -- including the NaN-boxing,
+// the `'{default: fpnew_pkg::DONT_CARE}` for formats outside FpDstFmtConfig and
+// the `dst_fmt` selects (which is what gates `result_is_special` to 0 when the
+// destination format is not built).
+module fpnew_mxdotp_special_assemble
+  import fpnew_mxdotp_multi_pkg::*;
+#(
+  parameter fpnew_pkg::fmt_logic_t FpDstFmtConfig = MxdotpDstFpFmtConfig
+) (
+  input  logic                  result_is_special_raw,
+  input  logic                  special_nv,
+  input  logic                  special_is_inf,
+  input  logic                  special_inf_sign,
+  input  fpnew_pkg::fp_format_e dst_fmt,
+  output logic [DST_WIDTH-1:0]  special_result,
+  output fpnew_pkg::status_t    special_status,
+  output logic                  result_is_special
+);
   logic               [NUM_FORMATS-1:0][DST_WIDTH-1:0] fmt_special_result;
   fpnew_pkg::status_t [NUM_FORMATS-1:0]                fmt_special_status;
   logic               [NUM_FORMATS-1:0]                fmt_result_is_special;
 
   for (genvar fmt = 0; fmt < int'(NUM_FORMATS); fmt++) begin : gen_special_results
-    // Set up some constants
     localparam int unsigned FP_WIDTH = fpnew_pkg::fp_width(fpnew_pkg::fp_format_e'(fmt));
     localparam int unsigned EXP_BITS = fpnew_pkg::exp_bits(fpnew_pkg::fp_format_e'(fmt));
     localparam int unsigned MAN_BITS = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
@@ -387,39 +440,12 @@ module fpnew_mxdotp_special_cases
     if (FpDstFmtConfig[fmt]) begin : active_format
       always_comb begin : special_cases
         logic [FP_WIDTH-1:0] special_res;
-
-        // Default assignment
-        special_res                = {1'b0, QNAN_EXPONENT, QNAN_MANTISSA}; // qNaN
+        special_res                = special_is_inf
+                                   ? {special_inf_sign, QNAN_EXPONENT, ZERO_MANTISSA}
+                                   : {1'b0,             QNAN_EXPONENT, QNAN_MANTISSA};
         fmt_special_status[fmt]    = '0;
-        fmt_result_is_special[fmt] = 1'b0;
-
-        // Handle potentially mixed nan & infinity input => important for the case where infinity and
-        // zero are multiplied and added to a qNaN.
-        // RISC-V mandates raising the NV exception in these cases:
-        // (inf * 0) + c or (0 * inf) + c INVALID, no matter c (even quiet NaNs)
-        if (any_produced_nan) begin
-          fmt_result_is_special[fmt] = 1'b1; // bypass OP, output is the canonical qNaN
-          fmt_special_status[fmt].NV = 1'b1; // invalid operation
-        // NaN Inputs cause canonical quiet NaN at the output and maybe invalid OP
-        end else if (any_operand_nan) begin
-          fmt_result_is_special[fmt] = 1'b1;           // bypass OP, output is the canonical qNaN
-          fmt_special_status[fmt].NV = signalling_nan; // raise the invalid operation flag if signalling
-        // Special cases involving infinity
-        end else if (any_operand_inf) begin
-          fmt_result_is_special[fmt] = 1'b1; // bypass OP
-          // Effective addition of opposite infinities (±inf - ±inf) is invalid!
-          if (any_pos_inf && any_neg_inf) begin
-            fmt_special_status[fmt].NV = 1'b1; // invalid operation
-          // Handle cases where output will be inf because of inf product input
-          end else if (any_pos_inf) begin
-            // Result is infinity with the positive sign
-            special_res = {1'b0, QNAN_EXPONENT, ZERO_MANTISSA};
-          // Handle cases where the second product is inf
-          end else if (any_neg_inf) begin
-            // Result is infinity with the negative sign
-            special_res = {1'b1, QNAN_EXPONENT, ZERO_MANTISSA};
-          end
-        end
+        fmt_special_status[fmt].NV = special_nv;
+        fmt_result_is_special[fmt] = result_is_special_raw;
         // Initialize special result with ones (NaN-box)
         fmt_special_result[fmt]               = '1;
         fmt_special_result[fmt][FP_WIDTH-1:0] = special_res;
@@ -431,26 +457,36 @@ module fpnew_mxdotp_special_cases
     end
   end
 
-  // Detect special case from source format
   assign result_is_special = fmt_result_is_special[dst_fmt];
-  // Signalling input NaNs raise invalid flag, otherwise no flags set
-  assign special_status = fmt_special_status[dst_fmt];
-  // Assemble result according to destination format
-  assign special_result = fmt_special_result[dst_fmt];
+  assign special_status    = fmt_special_status[dst_fmt];
+  assign special_result    = fmt_special_result[dst_fmt];
 endmodule
 
 // Adds two signed 8-bit scale values to produce a 9-bit combined scale.
 module fpnew_mxdotp_scale_adder
   import fpnew_mxdotp_multi_pkg::*;
-(
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1) // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+) (
   // Input signals
   input  logic signed [1:0][SCALE_WIDTH-1:0] operands_c,
-  output logic signed [SCALE_WIDTH:0] scale // +1 for addition
+  // The LZC-INDEPENDENT part of the final exponent, i.e. the original
+  //   exponent_major = 127 - ANCHOR + scale + FIXED_SUM_WIDTH - 1
+  // with the constant folded into THIS adder's already-constant term.  The
+  // 9-bit `scale` never wraps (operands_c are 8-bit signed, so the
+  // sum lies in [-256,254]), hence scale + 187 in [-69,441] is exact in
+  // DST_EXP_WIDTH=10 bits and this is bit-identical to the original two-step
+  // computation.  `scale` itself has no other consumer once
+  // fpnew_mxdotp_accumulator_prep absorbs the same offset.
+  output logic signed [DST_EXP_WIDTH-1:0] exponent_major
 );
   // ------------------
   // Scale data path
   // ------------------
-  assign scale = signed'(operands_c[0]) + signed'(operands_c[1]);
+  localparam int EXP_MAJOR_OFFSET = 127 - int'(ANCHOR) + int'(FIXED_SUM_WIDTH) - 1;
+  assign exponent_major = signed'(operands_c[0]) + signed'(operands_c[1]) + EXP_MAJOR_OFFSET;
 endmodule
 
 // Multiplies two vectors of mantissas (with implicit bit prepended) element-wise, applying sign logic.
@@ -507,27 +543,47 @@ module fpnew_mxdotp_signed_vector_multiplier
   // Product data path
   // ------------------
   logic signed [LocalVectorSize-1:0][  PrecisionBits-1:0] mantissa_a, mantissa_b;
+  // Extra partial-product row that carries the FP8 sign (see below)
+  logic        [LocalVectorSize-1:0][  PrecisionBits-1:0] sign_row;
 
+  // ----------------------------------------------------------------------
+  // The FP8 sign no longer sits in FRONT of the multiplier array.
+  //
+  // The original code negated mantissa_a before multiplying, so the operand sign
+  // had to traverse a 4-bit negate (complement + increment) and the format
+  // mux before a single partial product could be formed.  For a magnitude
+  // a in [0,15] the 8-bit one's complement is exactly -a-1 in two's
+  // complement, hence
+  //       (-a) * b  ==  (~a) * b + b
+  // so the sign now costs ONE XOR on mantissa_a (a single gate, in
+  // parallel with the format mux) plus ONE extra row in the compressor
+  // tree the multiplier already builds.  Nothing downstream changes:
+  // product_signed is bit-identical.
+  // ----------------------------------------------------------------------
   for (genvar i = 0; i < LocalVectorSize; i++) begin : gen_mantissa_fp8
+    logic sign_prod;
+    assign sign_prod = operands_a[i].sign ^ operands_b[i].sign;
     always_comb begin
       if (src_is_int && int_fmt == fpnew_pkg::INT8) begin : int8
         // For INT8, we use the full 8-bit mantissa
         mantissa_a[i] = operands_a[i][7:0];
         mantissa_b[i] = operands_b[i][7:0];
+        sign_row[i]   = '0;
       end else begin : fp8
         // Add implicit bits to mantissae and pad with zeros
-        mantissa_a[i] = {4'b0, info_a[i].is_normal, operands_a[i].mantissa};
+        mantissa_a[i] = {4'b0, info_a[i].is_normal, operands_a[i].mantissa}
+                        ^ {PrecisionBits{sign_prod}};
         mantissa_b[i] = {4'b0, info_b[i].is_normal, operands_b[i].mantissa};
-        if (operands_a[i].sign ^ operands_b[i].sign) begin
-          // If the signs are different, we need to negate one mantissa
-          mantissa_a[i] = -signed'(mantissa_a[i]);
-        end
+        sign_row[i]   = sign_prod
+                      ? {4'b0, info_b[i].is_normal, operands_b[i].mantissa}
+                      : '0;
       end
     end
   end
 
   for (genvar i = 0; i < LocalVectorSize; i++) begin : gen_mantissa
-    assign product_signed[i] = signed'(mantissa_a[i]) * signed'(mantissa_b[i]);
+    assign product_signed[i] = signed'(mantissa_a[i]) * signed'(mantissa_b[i])
+                             + signed'({{PrecisionBits{1'b0}}, sign_row[i]});
   end
 endmodule
 
@@ -574,7 +630,16 @@ module fpnew_mxdotp_product_shifter
           // sum of four 9-bit numbers can be at most 11 bits, for 69 bits output we need to shift by 69 - 11 = 58
           // 58-30=28 plus inherit 6 fractional bits from the multiplication -> point moves to 28+6=34
           // max shift can be 58 (28 + exp-max(30)), min shift is 0 (28 + exp-min(-28))
-          shifted_product[i] = signed'(product_signed[i]) << (signed'(SOP_SHIFT) + signed'(exponent_product[i]));
+          //
+          // In the FP8/FP8ALT branch both mantissae are 4-bit magnitudes
+          // (implicit bit + 3 mantissa bits), so the product lies in
+          // [-16*15, 15*15] = [-240,225] and product_signed[ProductBits-1:9]
+          // is pure sign extension of bit 8.  Only those 9 bits therefore
+          // have to enter the variable shifter -- the sign extension is
+          // re-created for free by the signed widening of the assignment.
+          // (Only the INT8 branch, whose shift amount is the CONSTANT
+          // ANCHOR and hence pure wiring, needs the full product width.)
+          shifted_product[i] = signed'(product_signed[i][2*PRECISION_BITS:0]) << (signed'(SOP_SHIFT) + signed'(exponent_product[i]));
         end
       end
     end else if (SrcFmt == fpnew_pkg::FP6) begin
@@ -584,6 +649,107 @@ module fpnew_mxdotp_product_shifter
     end else begin
       // exponent_product is negative only for zero inputs for FP4
       assign shifted_product[i] = signed'(product_signed[i]) << exponent_product[i];
+    end
+  end
+endmodule
+
+// Early half of fpnew_mxdotp_product_shifter: the per-lane product exponent.
+// Depends only on the (classified) operands, never on the product, so it can sit
+// in a different pipeline stage than the alignment shift below.
+module fpnew_mxdotp_product_exponent
+  import fpnew_mxdotp_multi_pkg::*;
+#(
+  parameter type         SrcType          = logic,
+  parameter int unsigned LocalVectorSize  = 8,
+  parameter int unsigned ExpWidth         = 8,
+  // Constant part of the alignment shift that the LATE half used to add to the
+  // product exponent (SOP_SHIFT for FP8, 4 for FP6, 0 for FP4).  It is folded
+  // into THIS adder, where it merges with the -2*bias constant of the same
+  // four-term sum and therefore costs nothing, instead of sitting as a separate
+  // carry-propagate stage in FRONT of the alignment shifter's select decode.
+  parameter int          ShiftOffset      = 0,
+  parameter int unsigned AmtWidth         = ExpWidth,
+  // When set, the alignment shift amount is forced to ALL ONES in the INT8
+  // case.  All ones is >= the late half's OutputWidth, so its variable shifter
+  // returns zero there, which is what lets fpnew_mxdotp_product_align drop the
+  // INT8/FP8 select from the low ANCHOR bits of its output (they are zero in
+  // BOTH arms).  Pure constant forcing: the FP8/FP6/FP4 value is untouched.
+  parameter bit          ForceOnInt8      = 1'b0
+) (
+  input  SrcType [LocalVectorSize-1:0] operands_a,
+  input  SrcType [LocalVectorSize-1:0] operands_b,
+  input  fpnew_pkg::fp_info_t [LocalVectorSize-1:0] info_a,
+  input  fpnew_pkg::fp_info_t [LocalVectorSize-1:0] info_b,
+  input  fpnew_pkg::fp_format_e src_fmt,
+  input  fpnew_pkg::int_format_e int_fmt,
+  input  logic src_is_int,
+  output logic [LocalVectorSize-1:0][AmtWidth-1:0] shift_amount
+);
+  logic force_int8;
+  assign force_int8 = ForceOnInt8 && src_is_int && (int_fmt == fpnew_pkg::INT8);
+  // Calculate the non-biased exponent of the product (verbatim from the former
+  // fpnew_mxdotp_product_shifter).
+  logic signed [LocalVectorSize-1:0][ExpWidth-1:0] exponent_product;
+
+  for (genvar i = 0; i < LocalVectorSize; i++) begin : gen_exponent_adjustment
+    assign exponent_product[i] = operands_a[i].exponent + info_a[i].is_subnormal
+                                + operands_b[i].exponent + info_b[i].is_subnormal
+                                - 2*signed'(bias_constant(src_fmt));
+    // AmtWidth is chosen wide enough (ExpWidth+1 wherever ShiftOffset != 0) that
+    // signed'(ShiftOffset) + signed'(exponent_product[i]) is representable, so
+    // this is the same integer the original code handed to `<<`.  Shift amounts that
+    // are negative there produced a >= 2**31 unsigned shift and hence an
+    // all-zero result; here they produce a >= 2**(AmtWidth-1) one, which is
+    // still wider than OutputWidth, hence the same all-zero result.
+    assign shift_amount[i] = AmtWidth'(signed'(ShiftOffset) + signed'(exponent_product[i]))
+                           | {AmtWidth{force_int8}};
+  end
+endmodule
+
+// Late half of the former fpnew_mxdotp_product_shifter: the variable alignment shift.
+// Body copied verbatim from that module; only the SHIFT AMOUNT now
+// arrives as a port, with the constant offset already folded in upstream.
+module fpnew_mxdotp_product_align
+  import fpnew_mxdotp_multi_pkg::*;
+#(
+  parameter int unsigned LocalVectorSize  = 8,
+  parameter fpnew_pkg::fp_format_e SrcFmt = fpnew_pkg::FP8,
+  parameter int unsigned ProductBits      = 4,
+  parameter int unsigned AmtWidth         = 8,
+  parameter int unsigned OutputWidth      = 70
+) (
+  input  logic [LocalVectorSize-1:0][ProductBits-1:0] product_signed,
+  // The FULL alignment shift amount, constant offset already applied upstream.
+  input  logic [LocalVectorSize-1:0][AmtWidth-1:0] shift_amount,
+  input  fpnew_pkg::int_format_e int_fmt,
+  input  logic src_is_int,
+  output logic signed [LocalVectorSize-1:0][OutputWidth-1:0] shifted_product
+);
+  // The original branch select, hoisted out of the per-lane loop.  The INT8
+  // arm `signed'(product_signed[i]) << ANCHOR` has its low ANCHOR bits ZERO,
+  // and the FP8 arm is zero for the WHOLE word whenever is_int8 because
+  // fpnew_mxdotp_product_exponent (ForceOnInt8=1) drives shift_amount to all
+  // ones there, which is >= OutputWidth.  The two arms are therefore disjoint
+  // and only the top OutputWidth-ANCHOR bits still need a select.
+  logic is_int8;
+  assign is_int8 = src_is_int && (int_fmt == fpnew_pkg::INT8);
+
+  for (genvar i = 0; i < LocalVectorSize; i++) begin : gen_align
+    if (SrcFmt == fpnew_pkg::FP8) begin : gen_align_fp8
+      localparam int unsigned HI_BITS = OutputWidth - ANCHOR;
+      logic signed [OutputWidth-1:0] barrel;
+      logic signed [HI_BITS-1:0]     int8_hi;
+      // Only the 9 significant product bits enter the variable shifter; the
+      // sign extension is re-created by the signed widening (as before).
+      assign barrel  = signed'(product_signed[i][2*PRECISION_BITS:0]) << shift_amount[i];
+      // Disjoint arms -> the select is an OR, and the gating collapses onto the
+      // ProductBits-wide product instead of the OutputWidth-wide shifted word.
+      logic [ProductBits-1:0] p_gated;
+      assign p_gated = product_signed[i] & {ProductBits{is_int8}};
+      assign int8_hi = signed'(p_gated);
+      assign shifted_product[i] = barrel | {int8_hi, {ANCHOR{1'b0}}};
+    end else begin : gen_align_other
+      assign shifted_product[i] = signed'(product_signed[i]) << shift_amount[i];
     end
   end
 endmodule
@@ -617,9 +783,9 @@ endmodule
 module fpnew_mxdotp_format_adder
   import fpnew_mxdotp_multi_pkg::*;
 #(
-  parameter int unsigned SoPFixedWidth = 70,
   parameter int unsigned Fp6SumWidth = FP6_PROD_SHIFT_WIDTH,
   parameter int unsigned Fp4SumWidth = FP4_PROD_SHIFT_WIDTH,
+  parameter int unsigned SoPFixedWidth = 70,
   // Do not change the following parameters
   localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1) // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
 ) (
@@ -641,33 +807,28 @@ endmodule
 
 // Shifts accumulator right to align with sum-of-products based on scale and accumulator exponent.
 // Computes shift amount, handles sticky bits, and detects if accumulator dominates the result.
-module fpnew_mxdotp_accumulator_shift
+// Early half of fpnew_mxdotp_accumulator_shift (STAGE 1): everything that
+// depends only on the classified accumulator operand, the scale and the
+// destination format -- i.e. the 24-bit conditional negate that builds
+// signed_mantissa_d and the four-term shift-amount sum.  Both sat in FRONT of
+// the 95-bit accumulator barrel shifter in stage 2; the accumulator lane of
+// stage 1 was empty (only the 9-bit scale adder), so they move into slack.
+// The INP-MID bank stops carrying info_d (8 b, this was its only consumer) and
+// carries the 25-bit signed mantissa and the 10-bit shift amount instead.
+module fpnew_mxdotp_accumulator_prep
   import fpnew_mxdotp_multi_pkg::*;
 #(
   parameter int unsigned SoPFixedWidth = 70,
   // Do not change the following parameters
-  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
-  localparam int signed MAX_ACC_SHIFT_AMOUNT = FIXED_SUM_WIDTH - DST_PRECISION_BITS - 1
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1) // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
 ) (
-  // Input signals
-  input  logic signed [FIXED_SUM_WIDTH-1:0] sum_product,
-  input  logic [SCALE_WIDTH:0] scale,
+  input  logic signed [DST_EXP_WIDTH-1:0] exponent_major,
   input  fp_dst_t operand_d,
   input  fpnew_pkg::fp_info_t info_d,
   input  fpnew_pkg::fp_format_e dst_fmt,
-  output logic result_is_accumulator,
-  output logic accumulator_is_right_shifted,
-  output logic signed [9:0] accumulator_right_shift_amount,
-  output logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining,
-  output logic accumulator_sticky,
-  output logic signed [DST_PRECISION_BITS :0] signed_mantissa_d,
-  output logic signed [FIXED_SUM_WIDTH-1:0] accumulator_shifted
+  output logic signed [9:0] accumulator_shift_amount,
+  output logic signed [DST_PRECISION_BITS :0] signed_mantissa_d
 );
-
-  // -----------------------------
-  // Accumulator shift data path
-  // -----------------------------
-  logic signed [9:0] accumulator_shift_amount;
   logic signed [DST_EXP_WIDTH-1:0] exponent_d;
   logic [DST_PRECISION_BITS-1:0] mantissa_d;
 
@@ -677,32 +838,80 @@ module fpnew_mxdotp_accumulator_shift
   assign signed_mantissa_d = operand_d.sign ? -mantissa_d : mantissa_d;
 
   // Calculate the shift amount for the accumulator, range=[-370,394-9b -> signed 10b]
-  assign accumulator_shift_amount = signed'(ANCHOR - SUPER_DST_MAN_BITS) - signed'(scale)
+  // exponent_major == scale + EXP_MAJOR_OFFSET exactly (no wrap, see
+  // fpnew_mxdotp_scale_adder), so -scale == EXP_MAJOR_OFFSET - exponent_major
+  // and the whole expression is the original integer, hence the original value
+  // after the truncation to 10 bits.
+  localparam int EXP_MAJOR_OFFSET = 127 - int'(ANCHOR) + int'(FIXED_SUM_WIDTH) - 1;
+  assign accumulator_shift_amount = signed'(int'(ANCHOR) - int'(SUPER_DST_MAN_BITS)
+                                            + EXP_MAJOR_OFFSET)
+                                     - signed'(exponent_major)
                                      + signed'(exponent_d + info_d.is_subnormal)
                                      - signed'(bias_constant(dst_fmt));
+endmodule
+
+module fpnew_mxdotp_accumulator_shift
+  import fpnew_mxdotp_multi_pkg::*;
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int signed MAX_ACC_SHIFT_AMOUNT = FIXED_SUM_WIDTH - DST_PRECISION_BITS - 1
+) (
+  // Input signals (pre-computed in stage 1 by fpnew_mxdotp_accumulator_prep)
+  input  logic signed [9:0] accumulator_shift_amount,
+  input  logic signed [DST_PRECISION_BITS :0] signed_mantissa_d,
+  output logic result_is_accumulator_uncond,
+  output logic result_is_accumulator_if_sop_zero,
+  output logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining,
+  output logic accumulator_sticky,
+  output logic signed [FIXED_SUM_WIDTH-1:0] accumulator_shifted
+);
+
+  // -----------------------------
+  // Accumulator shift data path
+  // -----------------------------
+  // {signed_mantissa_d, 24'b0} >>> accumulator_right_shift_amount_w, 49 bits.
+  // The shift amount is taken from a wire (not from the always_comb output) so
+  // that the funnel stays outside the procedural block.
+  logic signed [9:0] accumulator_right_shift_amount_w;
+  logic signed [2*DST_PRECISION_BITS:0] accumulator_funnel;
+  assign accumulator_right_shift_amount_w = -accumulator_shift_amount;
+  assign accumulator_funnel = signed'({signed_mantissa_d, {DST_PRECISION_BITS{1'b0}}})
+                              >>> accumulator_right_shift_amount_w;
 
   always_comb begin : accumulator_shift
-    result_is_accumulator = 1'b0;
-    accumulator_is_right_shifted = 1'b0;
-    accumulator_right_shift_amount = '0;
+    result_is_accumulator_uncond = 1'b0;
+    result_is_accumulator_if_sop_zero = 1'b0;
     accumulator_remaining = '0;
     accumulator_sticky = 1'b0;
     if (accumulator_shift_amount > MAX_ACC_SHIFT_AMOUNT) begin
       // SoP is too small to change the accumulator, result is the accumulator
       accumulator_shifted = '0;
-      result_is_accumulator = 1'b1;
+      result_is_accumulator_uncond = 1'b1;
     end else if (accumulator_shift_amount >= 0) begin
       accumulator_shifted = signed'(signed_mantissa_d) <<< accumulator_shift_amount;
     end else begin
-      accumulator_is_right_shifted = 1'b1;
-      accumulator_right_shift_amount = -accumulator_shift_amount;
-      accumulator_shifted = signed'(signed_mantissa_d) >>> accumulator_right_shift_amount;
-      if (accumulator_right_shift_amount > DST_PRECISION_BITS) begin
-        result_is_accumulator = (sum_product == '0) ? 1'b1 : 1'b0;
-        accumulator_remaining = signed'(signed_mantissa_d) >>> (accumulator_right_shift_amount - DST_PRECISION_BITS);
-        accumulator_sticky = |(signed'(signed_mantissa_d) & ((1 << (accumulator_right_shift_amount - DST_PRECISION_BITS)) - 1));
+      // ONE 49-bit arithmetic right shift serves both outputs: its top 25 bits
+      // are exactly signed'(signed_mantissa_d) >>> r evaluated in 25-bit
+      // arithmetic, whose 95-bit sign extension is the original wide shift,
+      // and its low 24 bits are accumulator_remaining (see below).
+      accumulator_shifted = FIXED_SUM_WIDTH'(signed'(
+          accumulator_funnel[2*DST_PRECISION_BITS:DST_PRECISION_BITS]));
+      // The two branches below differ only in the DIRECTION of a shift by
+      // |r - DST_PRECISION_BITS|, so they are one arithmetic right shift of
+      // the mantissa pre-placed at bit DST_PRECISION_BITS:
+      //   remaining = ({m, 24'b0} >>> r)[23:0]
+      // r <= 24 : bits [23:0] of the shifted word are m's bits from index
+      //           24-r downwards, i.e. exactly m << (24-r) truncated.
+      // r >  24 : the same slice is m >>> (r-24), sign-extended from the
+      //           49-bit container's MSB, which IS m's sign bit.
+      // One shifter instead of two; identical bits in both branches.
+      accumulator_remaining = accumulator_funnel[DST_PRECISION_BITS-1:0];
+      if (accumulator_right_shift_amount_w > DST_PRECISION_BITS) begin
+        result_is_accumulator_if_sop_zero = 1'b1;
+        accumulator_sticky = |(signed'(signed_mantissa_d) & ((1 << (accumulator_right_shift_amount_w - DST_PRECISION_BITS)) - 1));
       end else begin
-        accumulator_remaining = signed'(signed_mantissa_d) << (DST_PRECISION_BITS - accumulator_right_shift_amount);
         accumulator_sticky = 1'b0;
       end
     end
@@ -731,6 +940,97 @@ module fpnew_mxdotp_add_accumulator_sop
   assign sum_product_accumulator_extended = {sum_product_accumulator, accumulator_remaining};
 endmodule
 
+
+// Fused sum-of-products + accumulator adder.
+// Sums the eight aligned FP8/INT8 products, the (constant-shifted) FP6 and FP4
+// lane sums and the aligned accumulator in ONE arithmetic expression, so that
+// synthesis builds a single carry-save compressor tree with a single final CPA
+// instead of the three back-to-back carry-propagate stages (per-lane adder
+// tree -> format adder -> accumulator adder) of the original design.
+// `sum_product_is_zero` reproduces the original `sum_product == 0` test without
+// materialising sum_product: because the fused sum is computed modulo 2^95 and
+// sum_product is exactly 95 bits wide,
+//   sum_product == 0  <=>  (sum_product + accumulator_shifted) == accumulator_shifted.
+module fpnew_mxdotp_fused_sop_accumulator
+  import fpnew_mxdotp_multi_pkg::*;
+#(
+  parameter int unsigned LocalVectorSize = 8,
+  parameter int unsigned Fp6VectorSize   = 3,
+  parameter int unsigned Fp4VectorSize   = 5,
+  parameter int unsigned Fp6ProdWidth    = FP6_PROD_SHIFT_WIDTH,
+  parameter int unsigned Fp4ProdWidth    = FP4_PROD_SHIFT_WIDTH,
+  parameter int unsigned Fp6SumWidth     = FP6_PROD_SHIFT_WIDTH,
+  parameter int unsigned Fp4SumWidth     = FP4_PROD_SHIFT_WIDTH,
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS
+) (
+  input  logic signed [LocalVectorSize-1:0][PROD_SHIFT_WIDTH-1:0] shifted_product,
+  input  logic signed [Fp6VectorSize-1:0][Fp6ProdWidth-1:0]    fp6_shifted_product,
+  input  logic signed [Fp4VectorSize-1:0][Fp4ProdWidth-1:0]    fp4_shifted_product,
+  input  logic signed [FIXED_SUM_WIDTH-1:0]    accumulator_shifted,
+  input  logic signed [DST_PRECISION_BITS-1:0] accumulator_remaining,
+  output logic                                 sum_product_is_zero,
+  output logic signed [LZC_SUM_WIDTH-1:0]      sum_product_accumulator_extended
+);
+  logic signed [SoPFixedWidth-1:0] sum_product_fp8;
+  logic signed [Fp6SumWidth-1:0]     sum_product_fp6;
+  logic signed [Fp4SumWidth-1:0]     sum_product_fp4;
+  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_fp4_shifted;
+  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_fp6_shifted;
+  logic signed [FIXED_SUM_WIDTH-1:0] sum_product;
+  logic signed [FIXED_SUM_WIDTH-1:0] sum_product_accumulator;
+
+  // One arithmetic expression tree, one module: the FP8/INT8 lane sum, the FP6
+  // and FP4 lane sums, the format merge and the accumulator add are now a
+  // single datapath block, so synthesis compresses all SIXTEEN aligned terms in
+  // carry-save form and pays for exactly ONE carry-propagate adder at the end.
+  // Previously the FP6 (3 terms, 21 bit) and FP4 (5 terms, 9 bit) lane sums
+  // were separate carry-propagate adders sitting IN SERIES in front of this
+  // one.
+  //
+  // The association is unchanged (per-lane `+=` chains, then the format
+  // merge, then the accumulator), so no re-association is done in RTL --
+  // that is left to synthesis.  Each lane sum is exact
+  // at its own width (8 x 67b into 70b, 3 x 21b into 23b, 5 x 9b into 12b all
+  // fit without wrapping), so hoisting the lane sums into the same expression
+  // preserves the value bit for bit.
+  always_comb begin : sum_products_fp8
+    sum_product_fp8 = '0;
+    for (int i = 0; i < LocalVectorSize; i++) begin
+      sum_product_fp8 += signed'(shifted_product[i]);
+    end
+  end
+  always_comb begin : sum_products_fp6
+    sum_product_fp6 = '0;
+    for (int i = 0; i < Fp6VectorSize; i++) begin
+      sum_product_fp6 += signed'(fp6_shifted_product[i]);
+    end
+  end
+  always_comb begin : sum_products_fp4
+    sum_product_fp4 = '0;
+    for (int i = 0; i < Fp4VectorSize; i++) begin
+      sum_product_fp4 += signed'(fp4_shifted_product[i]);
+    end
+  end
+  assign sum_product_fp4_shifted = signed'(sum_product_fp4) << (SOP_SHIFT+2*(SUPER_MAN_BITS-FP4_MAN_BITS));
+  assign sum_product_fp6_shifted = signed'(sum_product_fp6) << (SOP_SHIFT-4+2*(SUPER_MAN_BITS-FP6_MAN_BITS));
+  assign sum_product             = sum_product_fp8 + sum_product_fp4_shifted + sum_product_fp6_shifted;
+  assign sum_product_accumulator = sum_product + accumulator_shifted;
+
+  // 70-bit test, not 95.  sum_product is the sum of a 70-bit-exact FP8 lane
+  // sum (|.| <= 2^69) and the FP6/FP4 lane terms (|.| <= 2^46 + 2^43), so its
+  // exact value has magnitude < 2^70 and is carried in the 95-bit container
+  // WITHOUT wrapping.  Hence sum_product == 0  <=>  sum_product[69:0] == 0,
+  // and because sum_product_accumulator = sum_product + accumulator_shifted
+  // (mod 2^95), that is exactly the equality of the low SoPFixedWidth bits.
+  // Twenty-five comparator bits and one level of the AND tree disappear.
+  assign sum_product_is_zero              = (sum_product_accumulator[SoPFixedWidth-1:0]
+                                             == accumulator_shifted[SoPFixedWidth-1:0]);
+  assign sum_product_accumulator_extended = {sum_product_accumulator, accumulator_remaining};
+endmodule
+
 // Converts results to sign-magnitude format using two's complement.
 module fpnew_mxdotp_twos_compl
   import fpnew_mxdotp_multi_pkg::*;
@@ -742,27 +1042,39 @@ module fpnew_mxdotp_twos_compl
 ) (
   // Input signals
   input  logic [LZC_SUM_WIDTH-1:0] sum_product_accumulator_extended,
-  input  logic signed [DST_PRECISION_BITS :0] signed_mantissa_d,
-  input  logic accumulator_is_right_shifted,
-  input  logic signed [9:0] accumulator_right_shift_amount,
-  input  logic accumulator_sticky,
   // Output signals
   output logic final_sign,
+  // ONE'S complement of the sum when negative (the +1 is applied in
+  // fpnew_mxdotp_norm_finalize, off the LZC path)
   output logic [LZC_SUM_WIDTH-1:0] sum_magnitude
 );
   // If sum is negative, complement to feed into leading zero counter
   assign final_sign = sum_product_accumulator_extended[LZC_SUM_WIDTH-1];
 
-  always_comb begin : get_twos_complement
-    if (final_sign) begin
-      sum_magnitude = ~sum_product_accumulator_extended + 1;
-      if (accumulator_is_right_shifted && accumulator_right_shift_amount > DST_PRECISION_BITS && signed_mantissa_d != 0 && accumulator_sticky) begin
-        sum_magnitude = ~sum_product_accumulator_extended;
-      end
-    end else begin
-      sum_magnitude = sum_product_accumulator_extended;
-    end
-  end
+  // The original code guarded the one's-complement (round-to-odd) case with
+  //   accumulator right-shifted by more than DST_PRECISION_BITS
+  //   && signed_mantissa_d != 0 && accumulator_sticky
+  // but `accumulator_sticky` already implies the other conjuncts:
+  // accumulator_shift only ever raises it inside the branch where the
+  // accumulator is right-shifted by more than DST_PRECISION_BITS, and it is
+  // an OR-reduction of a mask of signed_mantissa_d, so it can only be 1 when
+  // signed_mantissa_d != 0.
+  // The predicate therefore collapses to accumulator_sticky, which turns the
+  // conditional-complement's carry-in into a plain signal and drops a 10-bit
+  // comparator plus a 25-bit zero-test from this module.
+  // ------------------------------------------------------------------
+  // The +1 of the two's complement has MOVED DOWNSTREAM (see
+  // fpnew_mxdotp_norm_finalize).  This module now emits only the ONE'S
+  // complement `sum_magnitude_ones = x ^ {119{sign}}`, which is one XOR
+  // deep instead of a 119-bit carry-propagate incrementer.  The leading
+  // zero counter runs directly on it; norm_finalize both (a) re-applies
+  // the +1 for the window data, where there is slack, and (b) corrects
+  // the leading-zero count, which differs from the true one by exactly
+  // one only when ~x is 0^k 1^m (m>=1), i.e. when the magnitude is a
+  // power of two -- a condition detected in parallel with the LZC.
+  // ------------------------------------------------------------------
+  assign sum_magnitude = sum_product_accumulator_extended
+                       ^ {LZC_SUM_WIDTH{final_sign}};
 endmodule
 
 // Shifts magnitude left by normalization amount to align leading 1 to implicit bit position.
@@ -790,8 +1102,218 @@ module fpnew_mxdotp_norm_shift
   assign sum_shifted = sum_magnitude << norm_shamt;
 endmodule
 
+// Normalisation window extractor with fused sticky collection.
+//
+// The original design left-shifted the full LZC_SUM_WIDTH (=119) bit magnitude by
+// `norm_shamt` and then used only
+//     final_mantissa  = sum_shifted[118:95]      (the top DST_PRECISION_BITS)
+//     sticky_bits_or  = |sum_shifted[94:0]
+// i.e. it paid for a full 119-bit barrel shifter *and* a 95-bit OR tree.
+//
+// Algebraically, for X = sum_magnitude:
+//     final_mantissa = X[118-shamt : 95-shamt]   (bits below index 0 read as 0)
+//     sticky_bits_or = |X[94-shamt : 0]
+// so only a 24-bit *window* of X has to be routed to the output.  This module
+// therefore shifts coarse-to-fine and NARROWS the surviving word at every
+// stage, keeping only the bits that can still reach the 24-bit window:
+//     119 -> 87 -> 55 -> 39 -> 31 -> 27 -> 25 -> 24
+// which is 288 2:1 muxes instead of 7*119 = 833.
+//
+// The bits a stage drops off the bottom of the window are exactly the bits that
+// have fallen below index 95 of the shifted result, i.e. exactly the bits the
+// original 95-bit OR tree consumed.  So the sticky OR is collected *inside* the
+// narrowing (one small OR per stage, total 32+32+16+8+4+2+1 = 95 terms - the
+// same 95 bits, but ORed at seven shallow points instead of one deep tree).
+// In the d=2^k branch of a stage nothing is dropped, because the bits leaving
+// the bottom of the window there are the zeros shifted in from below.
+//
+// Invariant maintained across the pipeline of stages: `v` (W bits) equals
+// (X << p)[118 : 119-W], and `sticky` is the OR of all bits of (X << p) below
+// index 119-W.  Stage with shift d maps
+//     v' = v[W-1-d : W-W'-d]      (missing low indices are zeros)
+//     sticky' = sticky | (d ? 1'b0 : |v[W-W'-1 : 0])
+// Shift amounts >= LZC_SUM_WIDTH shift everything out in the original code (the shift
+// is evaluated in a 119-bit container), so they are detected up front and force
+// window and sticky to zero, which is what lets the seven low shift bits drive
+// the stages.
+module fpnew_mxdotp_norm_window
+  import fpnew_mxdotp_multi_pkg::*;
+#(
+  parameter int unsigned SoPFixedWidth = 70,
+  // Do not change the following parameters
+  localparam int unsigned FIXED_SUM_WIDTH = 1 + DST_PRECISION_BITS + 1 + (SoPFixedWidth - 1), // |s|-Acc:24b-|R|-unsigned SoP:64+log2k-|
+  localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS,
+  // Shift amount width: $clog2(DST_BIAS - ANCHOR + (scale_a+scale_b) + FIXED_SUM_WIDTH - 1)
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(fpnew_pkg::bias(fpnew_pkg::FP32) - ANCHOR + 2**(SCALE_WIDTH) - 1 + FIXED_SUM_WIDTH - 1)
+) (
+  input  logic [LZC_SUM_WIDTH-1:0]       sum_magnitude,
+  input  logic [SHIFT_AMOUNT_WIDTH-1:0]  norm_shamt,
+  output logic [DST_PRECISION_BITS-1:0]  final_mantissa,
+  output logic                           sticky_bits_or
+);
+  // Same narrowing invariant as before -- "v (W bits) == (X << p)[118 :
+  // 119-W], missing low indices zero" -- but the FOUR fine stages are replaced
+  // by ONE 16-way select, and the sticky those stages produced is kept by
+  // carrying only the handful of bits its ORs actually read.
+  //
+  //   coarse : 119 -> 87 -> 55 -> 39   (binary, shamt[6:4], unchanged)
+  //   fine   : v3[38-r : 15-r]         (one select on r = shamt[3:0])
+  //
+  // The original stages 4..7 are four multiplexer levels on the LATEST signal
+  // in the design (the shift amount comes straight out of the leading-zero
+  // count); a single 16-way select is one decoder plus one AND-OR level.
+  localparam int unsigned W0 = LZC_SUM_WIDTH;                     // 119
+  localparam int unsigned W1 = DST_PRECISION_BITS + 63;           //  87
+  localparam int unsigned W2 = DST_PRECISION_BITS + 31;           //  55
+  localparam int unsigned W3 = DST_PRECISION_BITS + 15;           //  39
+
+  // Only shift amounts >= 2**7 need explicit forcing: for 119 <= p <= 127 the
+  // window indices (118-p .. 95-p) are already all negative and the sticky
+  // range X[94-p:0] is already empty, so the chain returns the same zero
+  // by itself.  Catching only p >= 128 makes this one OR of two bits and lets
+  // the forcing sit at the FIRST stage instead of on the outputs at the end.
+  logic shift_out_all;
+  assign shift_out_all = (| norm_shamt[SHIFT_AMOUNT_WIDTH-1:7]);
+
+  logic [W1-1:0] v1; logic [W2-1:0] v2; logic [W3-1:0] v3;
+  logic s1, s2, s3, s4, s5, s6, s7;
+
+  assign v1 = shift_out_all ? '0
+                            : (norm_shamt[6] ? {sum_magnitude[W0-1-64:0], 32'b0}
+                                             : sum_magnitude[W0-1 -: W1]);
+  assign s1 = (shift_out_all | norm_shamt[6]) ? 1'b0 : |sum_magnitude[W0-W1-1:0];
+  assign v2 = norm_shamt[5] ? v1[W2-1:0] : v1[W1-1 -: W2];
+  assign s2 = norm_shamt[5] ? 1'b0      : |v1[W1-W2-1:0];
+  assign v3 = norm_shamt[4] ? v2[W3-1:0] : v2[W2-1 -: W3];
+  assign s3 = norm_shamt[4] ? 1'b0      : |v2[W2-W3-1:0];
+
+  // Fine extraction: final_mantissa == (X << p3+r)[118:95] == v3[38-r : 15-r]
+  always_comb begin : gen_fine
+    unique case (norm_shamt[3:0])
+      4'd0 : final_mantissa = v3[38:15];
+      4'd1 : final_mantissa = v3[37:14];
+      4'd2 : final_mantissa = v3[36:13];
+      4'd3 : final_mantissa = v3[35:12];
+      4'd4 : final_mantissa = v3[34:11];
+      4'd5 : final_mantissa = v3[33:10];
+      4'd6 : final_mantissa = v3[32:9];
+      4'd7 : final_mantissa = v3[31:8];
+      4'd8 : final_mantissa = v3[30:7];
+      4'd9 : final_mantissa = v3[29:6];
+      4'd10: final_mantissa = v3[28:5];
+      4'd11: final_mantissa = v3[27:4];
+      4'd12: final_mantissa = v3[26:3];
+      4'd13: final_mantissa = v3[25:2];
+      4'd14: final_mantissa = v3[24:1];
+      4'd15: final_mantissa = v3[23:0];
+    endcase
+  end
+
+  // Sticky tail: the fine stages only ever contribute the OR of the bits they
+  // drop, so the 31/27/25/24-bit windows of the original stages 4..7 collapse
+  // to the 7/3/1 bits those ORs actually read.  s4..s7 are bit-for-bit the
+  // original values, hence so is `sticky_bits_or`.
+  logic [6:0] t4;   // == v4[6:0]
+  logic [2:0] t5;   // == v5[2:0]
+  logic       t6;   // == v6[0]
+  assign t4 = norm_shamt[3] ? v3[6:0] : v3[14:8];
+  assign t5 = norm_shamt[2] ? t4[2:0] : t4[6:4];
+  assign t6 = norm_shamt[1] ? t5[0]   : t5[2];
+  assign s4 = norm_shamt[3] ? 1'b0 : |v3[7:0];
+  assign s5 = norm_shamt[2] ? 1'b0 : |t4[3:0];
+  assign s6 = norm_shamt[1] ? 1'b0 : |t5[1:0];
+  assign s7 = norm_shamt[0] ? 1'b0 : t6;
+
+  assign sticky_bits_or = s1 | s2 | s3 | s4 | s5 | s6 | s7;
+endmodule
+
 // Computes normalization shift amount and biased exponent from sign-magnitude sum via leading-zero
 // count. Handles subnormals (normalized_exponent = 0) and zero (lzc_zeroes path).
+
+// Leading-zero counter for the normalisation path (drop-in for common_cells
+// `lzc #(.WIDTH(119), .MODE(1))`, bit-identical on EVERY input including the
+// all-zero one, where both return cnt_o = 0).
+//
+// common_cells builds a BINARY reduction tree in which the index has to travel
+// through $clog2(WIDTH)=7 multiplexers whose selects are themselves OR trees;
+// which is deep, and it is the largest single block of the pre-normalisation
+// stage.  The tree below is RADIX-4: 128 padded
+// bits -> 32 -> 8 -> 2 -> 1, so the index crosses three 4:1 selects and one
+// 2:1 select while the `any` OR tree that drives those selects is only three
+// OR4 levels deep.  Each node emits the position of its FIRST set input, or
+// zero when it has none, which is what makes the all-zero result 0 without a
+// masking gate on the output.
+module fpnew_mxdotp_lzc119 #(
+  parameter int unsigned WIDTH     = 119,
+  parameter int unsigned CNT_WIDTH = 7
+) (
+  input  logic [WIDTH-1:0]     in_i,
+  output logic [CNT_WIDTH-1:0] cnt_o,
+  output logic                 empty_o
+);
+  localparam int unsigned PAD = 2**CNT_WIDTH;   // 128
+
+  // Flip so index 0 is the MSB of in_i (leading-zero mode), zero-pad to 4**k.
+  logic [PAD-1:0] f;
+  for (genvar i = 0; i < PAD; i++) begin : gen_flip
+    if (i < WIDTH) begin : g_real
+      assign f[i] = in_i[WIDTH-1-i];
+    end else begin : g_pad
+      assign f[i] = 1'b0;
+    end
+  end
+
+  // ---- level A: PAD/4 groups of four raw bits --------------------------
+  logic [PAD/4-1:0]      any_a;
+  logic [PAD/4-1:0][1:0] code_a;
+  for (genvar j = 0; j < PAD/4; j++) begin : gen_a
+    assign any_a[j]     = f[4*j] | f[4*j+1] | f[4*j+2] | f[4*j+3];
+    assign code_a[j][1] = ~f[4*j] & ~f[4*j+1] & (f[4*j+2] | f[4*j+3]);
+    assign code_a[j][0] = (~f[4*j] & f[4*j+1])
+                        | (~f[4*j] & ~f[4*j+1] & ~f[4*j+2] & f[4*j+3]);
+  end
+
+  // ---- level B: PAD/16 groups of four A-nodes --------------------------
+  logic [PAD/16-1:0]      any_b;
+  logic [PAD/16-1:0][3:0] code_b;
+  for (genvar j = 0; j < PAD/16; j++) begin : gen_b
+    logic [1:0] sel;
+    logic [1:0] pick;
+    assign any_b[j] = any_a[4*j] | any_a[4*j+1] | any_a[4*j+2] | any_a[4*j+3];
+    assign sel[1]   = ~any_a[4*j] & ~any_a[4*j+1] & (any_a[4*j+2] | any_a[4*j+3]);
+    assign sel[0]   = (~any_a[4*j] & any_a[4*j+1])
+                    | (~any_a[4*j] & ~any_a[4*j+1] & ~any_a[4*j+2] & any_a[4*j+3]);
+    assign pick     = (sel == 2'd0) ? code_a[4*j+0]
+                    : (sel == 2'd1) ? code_a[4*j+1]
+                    : (sel == 2'd2) ? code_a[4*j+2]
+                                    : code_a[4*j+3];
+    assign code_b[j] = {sel, pick};
+  end
+
+  // ---- level C: PAD/64 groups of four B-nodes --------------------------
+  logic [PAD/64-1:0]      any_c;
+  logic [PAD/64-1:0][5:0] code_c;
+  for (genvar j = 0; j < PAD/64; j++) begin : gen_c
+    logic [1:0] sel;
+    logic [3:0] pick;
+    assign any_c[j] = any_b[4*j] | any_b[4*j+1] | any_b[4*j+2] | any_b[4*j+3];
+    assign sel[1]   = ~any_b[4*j] & ~any_b[4*j+1] & (any_b[4*j+2] | any_b[4*j+3]);
+    assign sel[0]   = (~any_b[4*j] & any_b[4*j+1])
+                    | (~any_b[4*j] & ~any_b[4*j+1] & ~any_b[4*j+2] & any_b[4*j+3]);
+    assign pick     = (sel == 2'd0) ? code_b[4*j+0]
+                    : (sel == 2'd1) ? code_b[4*j+1]
+                    : (sel == 2'd2) ? code_b[4*j+2]
+                                    : code_b[4*j+3];
+    assign code_c[j] = {sel, pick};
+  end
+
+  // ---- level D: the two remaining C-nodes ------------------------------
+  logic sel_d;
+  assign sel_d   = ~any_c[0] & any_c[1];
+  assign empty_o = ~(any_c[0] | any_c[1]);
+  assign cnt_o   = {sel_d, (sel_d ? code_c[1] : code_c[0])};
+endmodule
+
 module fpnew_mxdotp_norm_lzc
   import fpnew_mxdotp_multi_pkg::*;
 #(
@@ -801,17 +1323,33 @@ module fpnew_mxdotp_norm_lzc
   localparam int unsigned LZC_SUM_WIDTH   = FIXED_SUM_WIDTH + DST_PRECISION_BITS,
   localparam int unsigned LZC_RESULT_WIDTH = $clog2(LZC_SUM_WIDTH)
 ) (
-  input  logic [LZC_SUM_WIDTH-1:0] sum_magnitude,
+  // ONE'S complement magnitude (the +1 lives in norm_finalize)
+  input  logic [LZC_SUM_WIDTH-1:0] sum_magnitude_ones,
+  // 1 when the true magnitude is sum_magnitude_ones + 1
+  input  logic                     mag_inc,
   output logic signed [LZC_RESULT_WIDTH:0] leading_zero_count_sgn,
   output logic lzc_zeroes
 );
   logic [LZC_RESULT_WIDTH-1:0] leading_zero_count;
+  logic [LZC_SUM_WIDTH-1:0]    lzc_in;
 
-  lzc #(
-    .WIDTH ( LZC_SUM_WIDTH ),
-    .MODE  ( 1             ) // MODE = 1 counts leading zeroes
+  // The counted word is the one's complement with the pending +1 OR'ed into
+  // bit 0.  Setting bit 0 cannot move the leading one of a non-zero word, so
+  // for every non-zero `sum_magnitude_ones` this is the plain one's-complement
+  // count.  It exists for the single case sum_magnitude_ones == 0 && mag_inc:
+  // the true magnitude is then 1, and the leading-zero counter reports 0
+  // (not 119) for an all-zero input, which would otherwise be used verbatim.
+  // With the OR the counter sees 1 and returns 118, the true count.
+  // It also makes `empty_o` exactly "true magnitude == 0": lzc_in == 0 iff
+  // sum_magnitude_ones == 0 and mag_inc == 0 (ones == '1 with mag_inc = 1
+  // would need x == 0, which forces final_sign = 0 and hence mag_inc = 0).
+  assign lzc_in = sum_magnitude_ones | {{(LZC_SUM_WIDTH-1){1'b0}}, mag_inc};
+
+  fpnew_mxdotp_lzc119 #(
+    .WIDTH     ( LZC_SUM_WIDTH    ),
+    .CNT_WIDTH ( LZC_RESULT_WIDTH ) // radix-4 drop-in, see above
   ) i_lzc (
-    .in_i    ( sum_magnitude      ),
+    .in_i    ( lzc_in             ),
     .cnt_o   ( leading_zero_count ),
     .empty_o ( lzc_zeroes         )
   );
@@ -833,51 +1371,120 @@ module fpnew_mxdotp_norm_finalize
   // Shift amount width: $clog2(DST_BIAS - ANCHOR + (scale_a+scale_b) + FIXED_SUM_WIDTH - 1)
   localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(fpnew_pkg::bias(fpnew_pkg::FP32) - ANCHOR + 2**(SCALE_WIDTH) - 1 + FIXED_SUM_WIDTH - 1)
 ) (
-  input  logic [LZC_SUM_WIDTH-1:0]          sum_magnitude,
+  // ONE'S complement magnitude straight out of fpnew_mxdotp_twos_compl
+  input  logic [LZC_SUM_WIDTH-1:0]          sum_magnitude_ones,
+  // RAW count/empty of sum_magnitude_ones (corrected below)
   input  logic signed [LZC_RESULT_WIDTH:0]  leading_zero_count_sgn,
   input  logic                              lzc_zeroes,
-  input  logic [SCALE_WIDTH:0]              scale,
+  // The LZC-independent part of the exponent, already assembled in stage 1
+  // (fpnew_mxdotp_scale_adder) and carried by the banks in place of `scale`.
+  input  logic signed [DST_EXP_WIDTH-1:0]   exponent_major,
+  input  logic                              final_sign,
   input  logic                              accumulator_sticky,
+  // Re-materialised true magnitude, so that every consumer of the original
+  // `sum_magnitude` still sees the original value (the rounder port).
+  output logic [LZC_SUM_WIDTH-1:0]          sum_magnitude_o,
   output logic [DST_PRECISION_BITS-1:0]     final_mantissa,
   output logic signed [DST_EXP_WIDTH-1:0]   final_exponent,
   output logic                              sticky_after_norm
 );
   logic signed [DST_EXP_WIDTH-1:0]      final_tentative_exponent;
+  logic                                 tentative_exponent_positive;
   logic        [SHIFT_AMOUNT_WIDTH-1:0] norm_shamt;
   logic signed [DST_EXP_WIDTH-1:0]      normalized_exponent;
 
-  logic [LZC_SUM_WIDTH-1:0]                    sum_shifted;
-  logic [LZC_SUM_WIDTH-DST_PRECISION_BITS-1:0] sum_sticky_bits;
+  logic                                        sticky_bits_or;
+
+  // ----------------------------------------------------------------------
+  // Re-apply the +1 of the two's complement, and correct the LZC for it.
+  //
+  // twos_compl now hands over  y = x ^ {119{final_sign}}  (one's complement
+  // when negative).  The true magnitude is  m = y + mag_inc  with
+  //     mag_inc = final_sign & !accumulator_sticky
+  // (the original code added `!accumulator_sticky` only in the negative branch).
+  //
+  // Leading zeros:  adding one to y moves the leading one up by exactly one
+  // position iff every bit below y's leading one is already 1, i.e. iff
+  // y = 0^k 1^m with m >= 1; then lzc(y+1) = lzc(y) - 1.  Otherwise the
+  // count is unchanged.  `y = 0^k 1^m, m>=1` is exactly "y[0] set and y
+  // contains no 0-followed-by-1 pattern", a flat AND/OR reduction of y that
+  // runs in PARALLEL with the LZC tree instead of in front of it.
+  //   * m = 0 (y == 0, true magnitude 1) is excluded here by the y[0] term
+  //     and is instead handled in fpnew_mxdotp_norm_lzc, which ORs mag_inc
+  //     into bit 0 of the counted word so the cell sees 1 and returns the
+  //     true count 118 (its all-zero output is 0, not 119).
+  //   * y[0] = 0 with y != 0 also needs no correction: the carry stops at
+  //     bit 0, and the OR in norm_lzc does not move a leading one either.
+  //   * y[118] = 0 whenever final_sign = 1, so lzc(y) >= 1 and the
+  //     decrement can never underflow.
+  // `lzc_zeroes` needs no correction: norm_lzc's counted word is zero
+  // exactly when the true magnitude is zero.
+  // ----------------------------------------------------------------------
+  logic                             mag_inc;
+  logic                             lzc_is_run;
+  logic                             lzc_dec;
+  logic [LZC_SUM_WIDTH-2:0]         run_break;
+  logic [LZC_SUM_WIDTH-1:0]         sum_magnitude;
+  logic signed [DST_EXP_WIDTH-1:0]  exponent_major_corr;
+
+  assign mag_inc       = final_sign & ~accumulator_sticky;
+  assign sum_magnitude = sum_magnitude_ones
+                       + {{(LZC_SUM_WIDTH-1){1'b0}}, mag_inc};
+
+  for (genvar i = 0; i < LZC_SUM_WIDTH-1; i++) begin : gen_run_break
+    assign run_break[i] = ~sum_magnitude_ones[i] & sum_magnitude_ones[i+1];
+  end
+  assign lzc_is_run     = sum_magnitude_ones[0] & ~(|run_break);
+  assign lzc_dec        = mag_inc & lzc_is_run;
 
   // Calculate the biased exponent (excess-127 form)
   // The exponent-major is -scaled_anchor
   // exponent = 127 - scaled_anchor + (94-count-1) + increment_exponent [-195, 315 9b -> 10b signed]
-  assign final_tentative_exponent = 127 - (signed'(ANCHOR) - signed'(scale))
-                                    + (signed'(FIXED_SUM_WIDTH) - leading_zero_count_sgn - 1); // 127 is bias of dst format
+  // `exponent_major` is the whole LZC-independent part: it only depends on the
+  // scale, so it is now built by the stage-1 scale adder and arrives as a port.
+  // true_lzc = leading_zero_count_sgn - lzc_dec, so every use of true_lzc is
+  // rewritten to move the correction onto the EARLY operand exponent_major.
+  assign exponent_major_corr      = exponent_major + signed'({1'b0, lzc_dec});
+  assign final_tentative_exponent = exponent_major_corr - leading_zero_count_sgn;
+
+  // final_tentative_exponent = exponent_major - lzc never wraps the 10-bit
+  // signed container (exponent_major in [-69,442], lzc in [0,118]), so the
+  // sign test is a plain magnitude comparison of an early operand against the
+  // LZC - a comparator, instead of a full subtract followed by a sign/zero test.
+  assign tentative_exponent_positive = signed'(exponent_major_corr) > signed'(leading_zero_count_sgn);
 
   // Normalization shift amount based on exponents and LZC (unsigned as only left shifts)
   always_comb begin : norm_shift_amount
-    if (final_tentative_exponent > 0 && !lzc_zeroes) begin
+    if (tentative_exponent_positive && !lzc_zeroes) begin
+      // true_lzc + 1 == leading_zero_count_sgn - lzc_dec + 1, but the -lzc_dec
+      // is INVISIBLE to fpnew_mxdotp_norm_window: lzc_dec implies the true
+      // magnitude is 2**(LZC_SUM_WIDTH-1-leading_zero_count_sgn+1), so both
+      // shift amounts push the single set bit out of the LZC_SUM_WIDTH-bit
+      // container and the window and its sticky are zero either way.  Only the
+      // exponent keeps the correction (exponent_major_corr above).
       norm_shamt          = leading_zero_count_sgn + 1;
       normalized_exponent = final_tentative_exponent;
     end else begin
-      norm_shamt          = leading_zero_count_sgn + final_tentative_exponent;
+      // lzc + (exponent_major - lzc) == exponent_major (mod 2**DST_EXP_WIDTH)
+      norm_shamt          = exponent_major[SHIFT_AMOUNT_WIDTH-1:0];
       normalized_exponent = '0; // subnormals encoded as 0
     end
   end
 
-  fpnew_mxdotp_norm_shift #(
-    .SoPFixedWidth  ( SoPFixedWidth )
-  ) i_norm_shift (
-    .sum_shifted  ( sum_shifted  ),
-    .sum_magnitude( sum_magnitude),
-    .norm_shamt   ( norm_shamt   )
+  // Extract the 24-bit normalised window directly and collect the sticky OR of
+  // the bits that fall below it inside the narrowing shifter.
+  fpnew_mxdotp_norm_window #(
+    .SoPFixedWidth ( SoPFixedWidth )
+  ) i_norm_window (
+    .sum_magnitude ( sum_magnitude  ),
+    .norm_shamt    ( norm_shamt     ),
+    .final_mantissa( final_mantissa ),
+    .sticky_bits_or( sticky_bits_or )
   );
 
-  // LSB of final mantissa is the rounding bit
-  assign {final_mantissa, sum_sticky_bits} = sum_shifted;
+  assign sum_magnitude_o                   = sum_magnitude;
   assign final_exponent                    = normalized_exponent;
-  assign sticky_after_norm                 = (|sum_sticky_bits) | accumulator_sticky;
+  assign sticky_after_norm                 = sticky_bits_or | accumulator_sticky;
 endmodule
 
 // Rounds normalized result to destination format with IEEE rounding modes (RNE/RTZ/RDN/RUP/RMM).
@@ -925,6 +1532,29 @@ module fpnew_mxdotp_rounder
   logic [SUPER_DST_EXP_BITS+SUPER_DST_MAN_BITS-1:0] rounded_abs; // absolute value of result after rounding
   logic                                             result_zero;
 
+  // ------------------------------------------------------------------
+  // of/uf AFTER ROUNDING, COMPUTED FROM THE PRE-ROUND OPERANDS.
+  //
+  // rounded_abs = pre_round_abs + round_up, and pre_round_abs is the
+  // zero-extension of {pre_round_exponent, pre_round_mantissa}, so the only
+  // way the rounding increment can reach the exponent field is a carry out
+  // of the mantissa field:
+  //     carry_into_exponent = round_up & (pre_round_mantissa == '1)
+  // `pre_round_exponent` is at most 2**EXP_BITS-2 (the of_before_round branch
+  // clamps it to exactly that, and otherwise final_exponent < 2**EXP_BITS-1),
+  // hence  pre_round_exponent + carry  can neither wrap to 0 nor reach all
+  // ones without the carry, which gives
+  //     uf_after_round = (pre_round_exponent == 0)         & ~carry
+  //     of_after_round = (pre_round_exponent == 2**E - 2)  &  carry
+  // Both are bit-identical to the old `rounded_abs[E+M-1:M] == 0 / '1`, but
+  // they no longer sit behind the carry-propagate rounding incrementer: the
+  // status cone now leaves `final_mantissa` through one AND reduction.
+  // ------------------------------------------------------------------
+  logic [NUM_FORMATS-1:0] fmt_exp_is_zero;   // pre_round_exponent == 0
+  logic [NUM_FORMATS-1:0] fmt_exp_is_max1;   // pre_round_exponent == 2**EXP_BITS-2
+  logic [NUM_FORMATS-1:0] fmt_man_all_ones;  // &pre_round_mantissa
+  logic                   round_up_pre;      // replica of fpnew_rounding's decision
+
   // Classification before round. RISC-V mandates checking underflow AFTER rounding
   assign of_before_round = final_exponent >= 2**(fpnew_pkg::exp_bits(dst_fmt))-1; // infinity exponent is all ones
 
@@ -945,6 +1575,11 @@ module fpnew_mxdotp_rounder
       // Assemble result before rounding. In case of overflow, the largest normal value is set.
       assign fmt_pre_round_abs[fmt] = {pre_round_exponent, pre_round_mantissa}; // 0-extend
 
+      // Pre-round predicates for the of/uf classification below
+      assign fmt_exp_is_zero[fmt]   = ~(| pre_round_exponent);
+      assign fmt_exp_is_max1[fmt]   = (pre_round_exponent == EXP_BITS'(2**EXP_BITS-2));
+      assign fmt_man_all_ones[fmt]  = (& pre_round_mantissa);
+
       // Round bit is after mantissa (1 in case of overflow for rounding)
       assign fmt_round_sticky_bits[fmt][1] = final_mantissa[SUPER_DST_MAN_BITS-MAN_BITS] |
                                              of_before_round;
@@ -959,6 +1594,9 @@ module fpnew_mxdotp_rounder
     end else begin : inactive_format
       assign fmt_pre_round_abs[fmt] = '{default: fpnew_pkg::DONT_CARE};
       assign fmt_round_sticky_bits[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_exp_is_zero[fmt]   = 1'b0;
+      assign fmt_exp_is_max1[fmt]   = 1'b0;
+      assign fmt_man_all_ones[fmt]  = 1'b0;
     end
   end
 
@@ -968,6 +1606,30 @@ module fpnew_mxdotp_rounder
   // In case of overflow, the round and sticky bits are set for proper rounding
   assign round_sticky_bits  = fmt_round_sticky_bits[dst_fmt];
   assign pre_round_sign     = final_sign;
+
+  // Bit-identical copy of fpnew_rounding's `rounding_decision` always_comb
+  // (EnableRSR = 0 as instantiated below, so RSR is the DONT_CARE branch).
+  // It reads exactly the signals that block reads, so round_up_pre is the
+  // same function of the same inputs as the round_up inside the instance.
+  always_comb begin : rounding_decision_replica
+    unique case (rnd_mode)
+      fpnew_pkg::RNE:
+        unique case (round_sticky_bits)
+          2'b00,
+          2'b01:   round_up_pre = 1'b0;
+          2'b10:   round_up_pre = pre_round_abs[0];
+          2'b11:   round_up_pre = 1'b1;
+          default: round_up_pre = fpnew_pkg::DONT_CARE;
+        endcase
+      fpnew_pkg::RTZ: round_up_pre = 1'b0;
+      fpnew_pkg::RDN: round_up_pre = (| round_sticky_bits) ? pre_round_sign  : 1'b0;
+      fpnew_pkg::RUP: round_up_pre = (| round_sticky_bits) ? ~pre_round_sign : 1'b0;
+      fpnew_pkg::RMM: round_up_pre = round_sticky_bits[1];
+      fpnew_pkg::ROD: round_up_pre = ~pre_round_abs[0] & (| round_sticky_bits);
+      fpnew_pkg::RSR: round_up_pre = fpnew_pkg::DONT_CARE;
+      default:        round_up_pre = fpnew_pkg::DONT_CARE;
+    endcase
+  end
 
   // Perform the rounding
   fpnew_rounding #(
@@ -996,10 +1658,12 @@ module fpnew_mxdotp_rounder
     localparam int unsigned MAN_BITS = fpnew_pkg::man_bits(fpnew_pkg::fp_format_e'(fmt));
 
     if (FpDstFmtConfig[fmt]) begin : active_dst_format
+      logic carry_into_exponent;
+      assign carry_into_exponent = round_up_pre & fmt_man_all_ones[fmt];
       always_comb begin : post_process
-        // detect of / uf
-        fmt_uf_after_round[fmt] = rounded_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == '0; // denormal
-        fmt_of_after_round[fmt] = rounded_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == '1; // inf exp.
+        // detect of / uf -- from the PRE-round operands, see the comment above
+        fmt_uf_after_round[fmt] = fmt_exp_is_zero[fmt] & ~carry_into_exponent; // denormal
+        fmt_of_after_round[fmt] = fmt_exp_is_max1[fmt] &  carry_into_exponent; // inf exp.
 
         // Assemble regular result, nan box short ones.
         fmt_result[fmt]               = '1;


### PR DESCRIPTION
## Summary

This is an LLM-assisted change: the restructuring below was proposed and
iterated by an LLM-driven optimisation flow, then reviewed by hand.

This PR restructures the internal datapath of `fpnew_mxdotp_multi` (files
`src/fpnew_mxdotp_multi.sv`, `src/mxdotp/fpnew_mxdotp_multi_modules.sv`) so that
the pipeline registers sit at narrower cut points and the per-stage logic depth
is shorter. It is a **functionally transparent** change:

* module interface, parameters (`FpSrcFmtConfig`, `IntSrcFmtConfig`,
  `NumPipeRegs`, `PipeConfig`, `LaneWidth`, `VectorSize`, ...), handshake and
  latency are unchanged;
* the pipeline-register allocation (`NUM_INP_REGS`, `NUM_IM_REGS`,
  `NUM_MID_REGS`, `NUM_MO_EARLY_REGS`, `NUM_MO_LATE_REGS`, `NUM_OUT_REGS`) and
  the `PipeConfig` semantics are byte-identical to `eb505fe`;
* results are bit-identical to `eb505fe` for every source format and pipeline
  configuration, at every `VectorSize` for which the FP6 remainder interface
  is well defined (`8*VectorSize mod 6 == 4`, e.g. 8, 32; at `VectorSize = 16`
  FP6/FP6ALT read past the 2-bit `operands_*_fp6_rem_i` port on `eb505fe`
  and on this branch alike).

`fpnew_mxdotp_multi_pkg.sv` and everything outside `mxdotp` are untouched.

The PR is four commits: (1) the datapath restructuring, (2) a width-generic
rewrite of one stage in the new normalisation window, (3) removal of the
submodules that are no longer instantiated, (4) a one-line fix of a
pre-existing FP6 lane-extraction bug for `VectorSize != 8`.

### Scope: tuned for `NumPipeRegs = 3`

The restructuring was done for one pipeline configuration only:
`NumPipeRegs = 3`, `PipeConfig = INSIDE`, i.e. register banks at IM, MID and
MO_LATE (`NUM_IM_REGS = NUM_MID_REGS = NUM_MO_LATE_REGS = 1`, all others 0).
"Stage *n*" below means the combinational logic between consecutive banks in
that configuration:

* stage 1: inputs → IM bank (classification, multipliers, hoisted exponent /
  shift-amount arithmetic);
* stage 2: IM → MID bank (alignment shifters, fused SoP + accumulator add);
* stage 3: MID → MO_LATE bank (two's complement, LZC, normalisation window);
* output: MO_LATE bank → outputs (rounding, status, special-value assembly).

Every other `NumPipeRegs` / `PipeConfig` still elaborates and produces the
same results as `eb505fe` (the bank positions are untouched), but no effort
was made to balance the logic for those configurations; in particular the
combinational (`NumPipeRegs = 0`) depth is the sum of the three stages either
way.

## What changed

### 1. Re-cut pipeline banks

The bank *positions* (`NUM_*_REGS`, `PipeConfig`) are unchanged; what each bank
holds is not. Widths quoted for `VectorSize = 8`, FP32 accumulator.

| bank | `eb505fe` | this PR |
|---|---|---|
| IM (INP-MID) bank | aligned products (8×67 + FP6/FP4 lanes ≈ 644 b), accumulator operand + `fp_info_t`, scale | raw products + per-lane *complete* shift amount (258 b), pre-negated accumulator mantissa + its shift amount, `exponent_major` |
| MID bank | 95-bit sum of products, accumulator operand + `fp_info_t`, scale (accumulator aligned and added *behind* the bank) | 119-bit fused SoP+accumulator result, its zero flag, the two raw accumulator verdicts, `exponent_major` |
| MO_EARLY / MO_LATE / OUT banks | 95-bit `sum_product` word carried along for the zero test, 32-bit special result + 5-bit status | 1-bit `sum_product_is_zero`, 4-bit special verdict `{result_is_special, nv, is_inf, inf_sign}` re-expanded at the output (`fpnew_mxdotp_special_assemble`) |

So the alignment barrel shifters and the fused adder now sit in the same stage
(between INP-MID and MID), while stage 1 is the multipliers plus the narrow
exponent/shift-amount arithmetic hoisted in front of them.

### 2. Stage 1: hoist everything that does not depend on the products

* **`fpnew_mxdotp_product_exponent`** (new, replaces the early half of
  `fpnew_mxdotp_product_shifter`): computes the per-lane alignment shift amount
  in stage 1 with the constant offset (`SOP_SHIFT` = 28 for FP8, 4 for FP6)
  folded into the exponent adder, so stage 2 no longer has an adder in front of
  the barrel shifter. For the FP8 instance the INT8 and FP8 alignment arms are
  made *disjoint*: on INT8 the shift amount is forced out of range
  (`AmtWidth = ExpWidth+1` bits, all ones ≥ `OutputWidth`), so the 67-bit × 8-lane
  format multiplexer in the aligner collapses into an OR that is free on the
  low `ANCHOR` bits.
* **`fpnew_mxdotp_product_align`** (new, the late half of the old shifter): just
  the variable barrel shift, behind the INP-MID bank.
* **`fpnew_mxdotp_accumulator_prep`** (new, split off `fpnew_mxdotp_accumulator_shift`
  at its narrow waist): the 24-bit conditional negate of the accumulator mantissa
  and the 4-term accumulator shift-amount sum move into stage 1; the INP-MID bank
  carries `signed_mantissa` + shift amount instead of the info word.
* `exponent_major` (= scale + constant offset) is computed once by the stage-1
  scale adder and carried through the banks instead of the raw scale, so the
  10-bit constant adder in `fpnew_mxdotp_norm_finalize` disappears.
* Classifier wiring: each format's classifier input is an elaboration-time
  choice of the operand packing that holds when `src_fmt == fmt` (its output is
  only ever read through `[src_fmt]`), removing the `src_fmt` multiplexer in
  front of the classifier bank.
* **`fpnew_mxdotp_signed_vector_multiplier`**: the FP8 sign is taken out of
  the front of the multiplier array. Instead of negating `mantissa_a` before
  the multiply, `mantissa_a` is one's-complemented (one XOR) and `mantissa_b`
  is added as one extra partial-product row, using `(-a)*b == (~a)*b + b`.
  `product_signed` is bit-identical.

### 3. Stage 2: fused sum-of-products + accumulator

* **`fpnew_mxdotp_fused_sop_accumulator`** (new, replaces the
  `adder_tree` / `format_adder` / `add_accumulator_sop` chain): one signed
  reduction of the FP8 lanes, the FP6/FP4 lane sums and the aligned accumulator.
* The SoP-is-zero test is taken on the low `SoPFixedWidth` bits (70 at
  `VectorSize = 8`) instead of the full 95-bit container; the exact SoP magnitude
  is bounded below `2**SoPFixedWidth`, so the two tests agree (argument in the
  source comment).
* The two accumulator verdicts (`result_is_accumulator` operands) are registered
  raw and combined behind the MID bank.

### 4. Stage 3: normalisation

* **`fpnew_mxdotp_norm_window`** (new, replaces `fpnew_mxdotp_norm_shift`): the
  normalisation left shift is three coarse binary stages (`shamt[6:4]`) followed
  by a single 16-way select for the fine amount (`shamt[3:0]`), with the sticky
  of the dropped bits carried on 7/3/1 bits instead of full-width windows.
* **`fpnew_mxdotp_lzc119`** (new): a radix-4 leading-zero counter, bit-identical
  to `lzc #(.MODE(1))` from `common_cells` on every input including all-zero.
* `fpnew_mxdotp_twos_compl` hands over the *one's* complement magnitude; the
  pending `+1` is re-applied in `norm_finalize` and its effect on the LZC
  (`lzc_dec`) is folded into `exponent_major`. The correction is dropped from
  `norm_shamt` itself, where the window provably cannot observe it.
* The two early output selects (special / accumulator pass-through) are merged
  so the rounder tail sees one 2:1 level.

### 5. Output

* Overflow / underflow after rounding are derived from the pre-round operands,
  taking the status cone off the rounding incrementer.

### Modules

New: `fpnew_mxdotp_special_assemble`, `fpnew_mxdotp_product_exponent`,
`fpnew_mxdotp_product_align`, `fpnew_mxdotp_accumulator_prep`,
`fpnew_mxdotp_fused_sop_accumulator`, `fpnew_mxdotp_norm_window`,
`fpnew_mxdotp_lzc119`.

Removed (third commit, no remaining instances): `fpnew_mxdotp_product_shifter`,
`fpnew_mxdotp_adder_tree`, `fpnew_mxdotp_format_adder`,
`fpnew_mxdotp_add_accumulator_sop`, `fpnew_mxdotp_norm_shift`.

### `VectorSize != 8` fix (second commit)

The first cut of `fpnew_mxdotp_norm_window` built its shift-by-64 stage as
`{sum_magnitude[W0-65:0], 32'b0}`, which is only the top-87-bit window of
`X << 64` when `LZC_SUM_WIDTH == 119` (i.e. `VectorSize == 8`). At
`VectorSize = 32` (`LZC_SUM_WIDTH = 121`) it silently dropped two leading bits
for normalisation shifts ≥ 64. The second commit writes the stage as a constant
shift so it is correct for any width, and adds an elaboration-time `$fatal`
guard for the `64 < LZC_SUM_WIDTH <= 128` range the window assumes
(`VectorSize <= 4096`). At `VectorSize = 8` the two forms select the same wires.

### FP6 lane extraction for `VectorSize != 8` (fourth commit)

Pre-existing on `eb505fe`: `fpnew_mxdotp_multi.sv` reads the FP6 remainder lanes
from `flat_operands_{a,b}_q` at a hard-coded offset of `48` (= 8·6), so
FP6/FP6ALT results were wrong for any `VectorSize` other than 8 (e.g. 32). The
offset is now `VectorSize*6`. `VectorSize = 8` is unchanged. This does not
change the FP6 remainder interface itself, so `VectorSize` values whose
`8*VectorSize mod 6 != 4` (e.g. 16) remain unsupported for FP6/FP6ALT as before.
